### PR TITLE
Show error students

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -15,6 +15,10 @@ type Student = {
     availabilities: Availability[];
 }
 
+type FailedStudent = Student & {
+    failedError: string;
+}
+
 type Cohort = {
     id: string;
     name: string;

--- a/src/pages/students/FailedStudentsModal.tsx
+++ b/src/pages/students/FailedStudentsModal.tsx
@@ -21,7 +21,7 @@ const BootstrapDialog = styled(Dialog)(({ theme }) => ({
 interface Props {
   isModalOpen: boolean
   onClose: () => void
-  failedStudents: Student[]
+  failedStudents: FailedStudent[]
 }
 
 const FailedStudentsModal: React.FC<Props> = ( { isModalOpen, onClose, failedStudents } ) => {
@@ -33,9 +33,9 @@ const FailedStudentsModal: React.FC<Props> = ( { isModalOpen, onClose, failedStu
         aria-labelledby="customized-dialog-title"
         open={isModalOpen}
       >
-        <Stack direction='row'>
+        <Stack direction='row' justifyContent='space-between'>
           <DialogTitle>
-            Some Uploads Failed:
+            Students that require attention:
           </DialogTitle>
           <IconButton
             aria-label="close"
@@ -45,18 +45,23 @@ const FailedStudentsModal: React.FC<Props> = ( { isModalOpen, onClose, failedStu
           </IconButton>
         </Stack>
         <DialogContent dividers>
-          {failedStudents.map((student: Student, idx: number) => (
+          {failedStudents.map((student: FailedStudent, idx: number) => (
               <List key={idx}>
                 <ListItem>
                   <ListItemText>
-                    {`ID: ${student.id} | Name: ${student.name}` }
+                    {`ID: ${student.id} | Name: ${student.name} | Error: ${student.failedError}` }
                   </ListItemText>
                 </ListItem>
               </List>
           ))}
         </DialogContent>
         <DialogActions>
-          <Button autoFocus onClick={onClose}>
+          <Button
+            autoFocus
+            onClick={onClose}
+            variant='contained'
+            color='primary'
+            >
             Close
           </Button>
         </DialogActions>

--- a/src/pages/students/FailedStudentsModal.tsx
+++ b/src/pages/students/FailedStudentsModal.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import { styled } from '@mui/material/styles';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import IconButton from '@mui/material/IconButton';;
+import { CloseCircleOutlined } from '@ant-design/icons';
+import { List, ListItem, ListItemText, Stack } from '@mui/material';
+
+const BootstrapDialog = styled(Dialog)(({ theme }) => ({
+  '& .MuiDialogContent-root': {
+    padding: theme.spacing(2),
+  },
+  '& .MuiDialogActions-root': {
+    padding: theme.spacing(1),
+  },
+}));
+
+interface Props {
+  isModalOpen: boolean
+  onClose: () => void
+  failedStudents: Student[]
+}
+
+const FailedStudentsModal: React.FC<Props> = ( { isModalOpen, onClose, failedStudents } ) => {
+
+  return (
+    <React.Fragment>
+      <BootstrapDialog
+        onClose={onClose}
+        aria-labelledby="customized-dialog-title"
+        open={isModalOpen}
+      >
+        <Stack direction='row'>
+          <DialogTitle>
+            Some Uploads Failed:
+          </DialogTitle>
+          <IconButton
+            aria-label="close"
+            onClick={onClose}
+          >
+            <CloseCircleOutlined />
+          </IconButton>
+        </Stack>
+        <DialogContent dividers>
+          {failedStudents.map((student: Student, idx: number) => (
+              <List key={idx}>
+                <ListItem>
+                  <ListItemText>
+                    {`ID: ${student.id} | Name: ${student.name}` }
+                  </ListItemText>
+                </ListItem>
+              </List>
+          ))}
+        </DialogContent>
+        <DialogActions>
+          <Button autoFocus onClick={onClose}>
+            Close
+          </Button>
+        </DialogActions>
+      </BootstrapDialog>
+    </React.Fragment>
+  );
+}
+
+export default FailedStudentsModal;

--- a/src/pages/students/StudentUploader.tsx
+++ b/src/pages/students/StudentUploader.tsx
@@ -54,7 +54,7 @@ function StudentUploader(props: any) {
                         failedStudents: allFailed,
                         successCount: allSuccess,
                         failedCount: allFailed.length,
-                        attemptedCount: studentFiles.length
+                        attemptedCount: allFailed.length + allSuccess
                     });
             })
             .catch((err) => {

--- a/src/pages/students/StudentUploader.tsx
+++ b/src/pages/students/StudentUploader.tsx
@@ -49,10 +49,22 @@ function StudentUploader(props: any) {
                 })
                 const allSuccess = resps.map(resp => resp.successCount)
                     .reduce((p, v) => p + v, 0);
+
+                    props.onChange({
+                        failedStudents: allFailed,
+                        successCount: allSuccess,
+                        failedCount: allFailed.length,
+                        attemptedCount: studentFiles.length
+                    });
+            })
+            .catch((err) => {
+                console.error('Unexpected Error: ', err)
                 props.onChange({
-                    failedStudents: allFailed,
-                    successCount: allSuccess
-                });
+                    failedStudents: [],
+                    successCount: 0,
+                    failedCount: studentFiles.length,
+                    attemptedCount: studentFiles.length
+                })
             });
     }, [])
 

--- a/src/pages/students/index.tsx
+++ b/src/pages/students/index.tsx
@@ -31,7 +31,17 @@ const UploadSection = () => {
     const handleUpdate = (resp: any) => {
         setRefresh(refresh + 1);
         setShowDropzone(false);
-        notifications.success(`Files are accepted, adding ${resp.successCount} students.`)
+        if (resp.failedCount > 0) {
+            notifications.warn(
+                `Attempted: ${resp.attemptedCount}
+                 ${resp.successCount} added, ${resp.failedCount} failed.
+            Failed Students: ${resp.failedStudents.map((student: any) => `- ID: ${student.id}, Name: ${student.name}`).join(' | ')}`
+            );
+        } else if (resp.successCount === resp.attemptedCount) {
+            notifications.success(`Successfully added ${resp.successCount} of ${resp.attemptedCount} students.`)
+        } else {
+            notifications.error(`Error uploading spreadsheet. Failed to add ${resp.successCount} of ${resp.attemptedCount}`)
+        }
     }
 
     return (

--- a/src/pages/students/index.tsx
+++ b/src/pages/students/index.tsx
@@ -28,23 +28,23 @@ const UploadSection = () => {
     const notifications = useNotifications();
     const { refresh, setRefresh } = useContext(RefreshContext);
     const [showDropzone, setShowDropzone] = useState<boolean>(false);
-    const [failedStudents, setFailedStudents] = useState<Student[]>([]);
+    const [failedStudents, setFailedStudents] = useState<FailedStudent[]>([]);
     const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
 
     const handleUpdate = (resp: any) => {
         setRefresh(refresh + 1);
         setShowDropzone(false);
-        if (resp.failedCount > 0) {
+        if (resp.failedCount === resp.attemptedCount) {
+            notifications.error(`Error uploading spreadsheet. Failed to add ${resp.successCount} of ${resp.attemptedCount}`)
+        } else if (resp.failedCount > 0) {
             setFailedStudents(resp.failedStudents)
             setIsModalOpen(true);
             notifications.warn(
                 `${resp.attemptedCount} Attempted, ${resp.successCount} added, ${resp.failedCount} failed.`
             );
-        } else if (resp.successCount === resp.attemptedCount) {
-            notifications.success(`Successfully added ${resp.successCount} of ${resp.attemptedCount} students.`)
         } else {
-            notifications.error(`Error uploading spreadsheet. Failed to add ${resp.successCount} of ${resp.attemptedCount}`)
+            notifications.success(`${resp.attemptedCount} Attempted, ${resp.successCount} successfully added`)
         }
     }
 

--- a/src/pages/students/index.tsx
+++ b/src/pages/students/index.tsx
@@ -22,20 +22,24 @@ import { MainCard } from '@digitalaidseattle/mui';
 import StudentsDetailsTable from './StudentsDetailsTable';
 import StudentUploader from './StudentUploader';
 import { RefreshContext, useNotifications } from '@digitalaidseattle/core';
+import FailedStudentsModal from './FailedStudentsModal';
 
 const UploadSection = () => {
     const notifications = useNotifications();
     const { refresh, setRefresh } = useContext(RefreshContext);
     const [showDropzone, setShowDropzone] = useState<boolean>(false);
+    const [failedStudents, setFailedStudents] = useState<Student[]>([]);
+    const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
 
     const handleUpdate = (resp: any) => {
         setRefresh(refresh + 1);
         setShowDropzone(false);
         if (resp.failedCount > 0) {
+            setFailedStudents(resp.failedStudents)
+            setIsModalOpen(true);
             notifications.warn(
-                `Attempted: ${resp.attemptedCount}
-                 ${resp.successCount} added, ${resp.failedCount} failed.
-            Failed Students: ${resp.failedStudents.map((student: any) => `- ID: ${student.id}, Name: ${student.name}`).join(' | ')}`
+                `${resp.attemptedCount} Attempted, ${resp.successCount} added, ${resp.failedCount} failed.`
             );
         } else if (resp.successCount === resp.attemptedCount) {
             notifications.success(`Successfully added ${resp.successCount} of ${resp.attemptedCount} students.`)
@@ -58,6 +62,11 @@ const UploadSection = () => {
             {showDropzone &&
                 <StudentUploader onChange={handleUpdate} />
             }
+            <FailedStudentsModal
+                isModalOpen={isModalOpen}
+                onClose={() => setIsModalOpen(false)}
+                failedStudents={failedStudents}
+            />
         </Stack>
     )
 }


### PR DESCRIPTION
## Description

- When uploading a sheet of students, the user will see notification with attempted, successful, and failed counts regarding inserts
- For failed inserts, the user will see a modal with student id and name, with a the generic returned error message, so they can change their source sheet and re-attempt upload
- *The service still uploads students even if some fail, which I believe we can change with validation logic prior to attempting an upload.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

https://das-culturousexchange-team.atlassian.net/browse/SCRUM-25

<img width="1178" alt="Screenshot 2025-02-07 at 6 02 03 PM" src="https://github.com/user-attachments/assets/fcc059bc-fa54-430c-bfc4-38c5acaa6e75" />

_Please replace this line with instructions on how to test your changes, as well as any relevant images for UI changes._

