### PR TITLE
CEMT-24 Feature Student Form Field Validation - Front End

### DIFF
--- a/src/pages/students/AddStudentModal.tsx
+++ b/src/pages/students/AddStudentModal.tsx
@@ -8,7 +8,41 @@ interface Props {
   handleAddStudent: (event: any) => void;
 }
 
-const AddStudent: React.FC<Props> = ( {isAddStudentModalOpen, onClose, handleAddStudent} ) => {
+const AddStudent: React.FC<Props> = ({ isAddStudentModalOpen, onClose, handleAddStudent }) => {
+  const onSubmit = (event: any) => {
+    const form = event.currentTarget as HTMLFormElement;
+
+    Array.from(form.elements).forEach((el: any) => {
+      if (el && typeof el.setCustomValidity === 'function') el.setCustomValidity('');
+    });
+
+    const nameInput = form.querySelector<HTMLInputElement>('input[name="name"]');
+    if (nameInput) {
+      const v = (nameInput.value || '').trim();
+      if (v.length < 4) nameInput.setCustomValidity('Name must be at least 4 characters');
+    }
+
+    const genderRadios = form.querySelectorAll<HTMLInputElement>('input[name="gender"]');
+    if (genderRadios.length && !Array.from(genderRadios).some(r => r.checked)) {
+      genderRadios[0].setCustomValidity('Please select a gender');
+    }
+
+    ['email', 'age', 'city', 'country'].forEach((n) => {
+      const el = form.querySelector<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>(`[name="${n}"]`);
+      if (el && typeof (el as any).value !== 'undefined') {
+        const val = String((el as any).value ?? '').trim();
+        if (!val) (el as any).setCustomValidity('This field is required');
+      }
+    });
+
+    if (!form.checkValidity()) {
+      event.preventDefault();
+      form.reportValidity();
+      return;
+    }
+
+    handleAddStudent(event);
+  };
 
   return (
     <React.Fragment>
@@ -18,7 +52,8 @@ const AddStudent: React.FC<Props> = ( {isAddStudentModalOpen, onClose, handleAdd
         PaperProps={{
           sx: { width: '40rem', maxWidth: '90vw' },
           component: 'form',
-          onSubmit: handleAddStudent,
+          noValidate: true,
+          onSubmit
         }}
       >
         <DialogTitle>New Student Details</DialogTitle>
@@ -27,18 +62,13 @@ const AddStudent: React.FC<Props> = ( {isAddStudentModalOpen, onClose, handleAdd
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose}>Cancel</Button>
-          <Button
-            type="submit"
-            color="primary"
-            variant="contained"
-            >
+          <Button type="submit" color="primary" variant="contained">
             Submit
           </Button>
         </DialogActions>
       </Dialog>
     </React.Fragment>
   );
-}
+};
 
 export default AddStudent;
-


### PR DESCRIPTION
Added front-end form validation for Student Form

## Description

- Added validation to the AddStudentModal form
- Combines browser validation with custom rules 

Side note, I wasn’t able to delete these test student accounts: 
- Julian: `Ju@email.com`, USA, 15
- Juliana: `Ju2@email`, USA, 15
- Juliani: `Ju3@email.com`, USA, 15


## What type of PR is this? 

[x] Feature
[x] Bug Fix


## Related Tickets & Documents

- Referenced validateSpreadsheet.ts ([PR #67](https://github.com/digitalaidseattle/culturous-exchange/pull/67))
- [CEMT-24 Feature Student Form Field Validation - Front End](https://digital-aid-seattle.atlassian.net/browse/CEMT-24?atlOrigin=eyJpIjoiZWMxMTMxOGQ2ZjZkNDM5NjlkYzgyNTU0Njg1YzYwNGEiLCJwIjoiaiJ9)



## QA Instructions, Screenshots, Recordings

- Open Add Student form 
- Try submitting with missing fields
- Fix the fields (form should allow resubmission; for text fields, click another field after fixing to clear the message; number and gender fields validate once corrected)

<img width="476" height="515" alt="image16" src="https://github.com/user-attachments/assets/a789bd38-2c0c-440a-9288-590f3aa8c962" />
<img width="477" height="515" alt="image18" src="https://github.com/user-attachments/assets/46b4941d-6dc6-46a8-b4f5-864fa6b4632a" />
<img width="521" height="517" alt="image22" src="https://github.com/user-attachments/assets/9df42b28-53f5-4b42-9c41-fc6eda8c9f20" />
<img width="753" height="90" alt="image23" src="https://github.com/user-attachments/assets/8394c8b6-0478-4bb3-989c-1f06ade7068a" />

