### PR TITLE
CEMT - 111 Add assignment table 

### DIFF
--- a/src/api/ceAssignmentService.ts
+++ b/src/api/ceAssignmentService.ts
@@ -1,0 +1,45 @@
+/**
+ * ceAssignmentService.ts
+ * Scaffold service for managing assignments (facilitator <-> group mapping)
+ */
+import { supabaseClient } from '@digitalaidseattle/supabase';
+import { v4 as uuid } from 'uuid';
+import { EntityService } from './entityService';
+import { Assignment } from './types';
+
+const DEFAULT_SELECT = '*';
+
+class CEAssignmentService extends EntityService<Assignment> {
+
+  empty(): Assignment {
+    return {
+      id: uuid(),
+      group_id: undefined,
+      facilitator_id: null
+    } as Assignment;
+  }
+
+  mapJson(json: any): Assignment {
+    return {
+      ...json
+    } as Assignment;
+  }
+
+  async findByGroupId(groupId: string, select?: string): Promise<Assignment | null> {
+    try {
+      return await supabaseClient
+        .from(this.tableName)
+        .select(select ?? DEFAULT_SELECT)
+        .eq('group_id', groupId)
+        .single()
+        .then((resp: any) => resp.data ?? null);
+    } catch (err) {
+      console.error('Unexpected error fetching assignment by group id', err);
+      throw err;
+    }
+  }
+
+}
+
+const assignmentService = new CEAssignmentService('assignment');
+export { assignmentService };

--- a/src/api/ceTimeWindowService.ts
+++ b/src/api/ceTimeWindowService.ts
@@ -278,6 +278,14 @@ class CETimeWindowService extends EntityService<TimeWindow> {
       .then((resp: any) => resp.data as unknown as TimeWindow[]);
   }
 
+  async findByAssignmentId(assignmentId: Identifier, select?: string): Promise<TimeWindow[]> {
+    return await supabaseClient
+      .from(this.tableName)
+      .select(select ?? '*')
+      .eq('assignment_id', assignmentId)
+      .then((resp: any) => resp.data as unknown as TimeWindow[]);
+  }
+
   async getTimeZone(city: string, country: string): Promise<{ timezone: string, offset: number }> {
     // return {
     //   timezone: 'America/Los_Angeles',
@@ -377,6 +385,24 @@ class CETimeWindowService extends EntityService<TimeWindow> {
         .from(this.tableName)
         .delete()
         .eq('facilitator_id', facilitatorId);
+
+      if (error) {
+        console.error(SERVICE_ERRORS.ERROR_DELETING_ENTITY, error.message);
+        throw new Error(SERVICE_ERRORS.FAILED_DELETE_ENTITY);
+      }
+      return true;
+    } catch (err) {
+      console.error(SERVICE_ERRORS.UNEXPECTED_ERROR_DELETION, err);
+      throw err;
+    }
+  }
+
+  async deleteByAssignmentId(assignmentId: Identifier): Promise<boolean> {
+    try {
+      const { error } = await supabaseClient
+        .from(this.tableName)
+        .delete()
+        .eq('assignment_id', assignmentId);
 
       if (error) {
         console.error(SERVICE_ERRORS.ERROR_DELETING_ENTITY, error.message);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -13,6 +13,7 @@ type Entity = {
 type TimeWindow = Entity & {
     student_id: Identifier | null;
     facilitator_id?: Identifier | null;
+    assignment_id?: Identifier | null;
     group_id: Identifier | null;
     day_in_week: string;
     start_t: string;
@@ -114,6 +115,13 @@ type Group = Entity & {
     time_windows?: TimeWindow[];
 }
 
+type Assignment = Entity & {
+    group_id: Identifier;
+    facilitator_id: Identifier | null;
+    created_at?: Date;
+    updated_at?: Date;
+}
+
 export type {
     TimeWindow,
     Enrollment,
@@ -127,5 +135,6 @@ export type {
     Group,
     Placement,
     Plan,
-    Facilitator
+    Facilitator,
+    Assignment
 }

--- a/supabase/migrations/000025_create_assignment_table.sql
+++ b/supabase/migrations/000025_create_assignment_table.sql
@@ -1,0 +1,62 @@
+-- Create assignments table linking a facilitator to a group (one facilitator per group)
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS assignment (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id uuid NOT NULL,
+  facilitator_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Ensure only one assignment exists per group
+CREATE UNIQUE INDEX IF NOT EXISTS idx_assignment_group_id ON assignment (group_id);
+
+-- Foreign keys
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+    WHERE tc.table_name = 'assignment' AND tc.constraint_type = 'FOREIGN KEY' AND kcu.column_name = 'group_id'
+  ) THEN
+    ALTER TABLE assignment
+      ADD CONSTRAINT fk_assignment_group
+      FOREIGN KEY (group_id) REFERENCES grouptable (id)
+      ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+    WHERE tc.table_name = 'assignment' AND tc.constraint_type = 'FOREIGN KEY' AND kcu.column_name = 'facilitator_id'
+  ) THEN
+    ALTER TABLE assignment
+      ADD CONSTRAINT fk_assignment_facilitator
+      FOREIGN KEY (facilitator_id) REFERENCES facilitators (id)
+      ON DELETE SET NULL;
+  END IF;
+END$$;
+
+-- 3) Add assignment_id to timewindow if it doesn't already exist and link to assignment
+ALTER TABLE timewindow
+  ADD COLUMN IF NOT EXISTS assignment_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+    WHERE tc.table_name = 'timewindow' AND tc.constraint_type = 'FOREIGN KEY' AND kcu.column_name = 'assignment_id'
+  ) THEN
+    ALTER TABLE timewindow
+      ADD CONSTRAINT fk_timewindow_assignment
+      FOREIGN KEY (assignment_id) REFERENCES assignment (id)
+      ON DELETE SET NULL;
+  END IF;
+END$$;
+
+COMMIT;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -208,3 +208,12 @@ INSERT INTO facilitators (id, name, email, time_zone, tz_offset, bio, active)
 VALUES
   ('00000000-0000-4000-8000-000000000001', 'Test Facilitator', 'facilitator@example.org', 'America/Los_Angeles', -480, 'Local test facilitator', true)
 ON CONFLICT (lower(email)) DO NOTHING;
+
+--
+-- Seed assignment (local testing): will only insert if the referenced group exists.
+--
+
+INSERT INTO assignment (id, group_id, facilitator_id)
+SELECT '00000000-0000-4000-8000-000000000010'::uuid, '00000000-0000-4000-8000-000000000002'::uuid, '00000000-0000-4000-8000-000000000001'::uuid
+WHERE EXISTS (SELECT 1 FROM grouptable WHERE id = '00000000-0000-4000-8000-000000000002'::uuid)
+ON CONFLICT (group_id) DO NOTHING;


### PR DESCRIPTION
## Description

This PR introduce Assignment, DB migration, types, minimal service, and seed data for local/dev.

Changes

1. Migration: 000025_create_assignment_table.sql
        - Creates assignment (id, group_id NOT NULL, facilitator_id, created_at, updated_at)
        - Unique index on group_id; FKs to grouptable(id) and facilitators(id)
        - Adds assignment_id to timewindow with FK → assignment(id)
2. Types & services:
        - types.ts: adds Assignment
        - ceAssignmentService.ts: new scaffold (mapJson + findByGroupId)
        - ceTimeWindowService.ts: helpers for assignment-aware ops
3. Seed: seed.sql includes conditional test insert

Verification

1. Applied locally and confirmed assignment table and timewindow.assignment_id exist.
2. FK relationships: assignment.group_id → grouptable, assignment.facilitator_id → facilitators.


<img width="1153" height="730" alt="image" src="https://github.com/user-attachments/assets/2c35709d-9919-4e28-aa1b-dbe504e093e8" />


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue #
- Closes # https://digital-aid-seattle.atlassian.net/browse/CEMT-111

## QA Instructions, Screenshots, Recordings

