### PR TITLE
Bug Fix CEMT-77: Persist anchor across pagination & propagate placement→student

### DIFF
--- a/src/api/cePlacementService.test.ts
+++ b/src/api/cePlacementService.test.ts
@@ -1,0 +1,52 @@
+/**
+ *  cePlacementService.test.ts
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock supabase client chain used in updatePlacement
+vi.mock('@digitalaidseattle/supabase', () => {
+  const single = vi.fn(() => Promise.resolve({ data: { plan_id: 'plan1', student_id: 'student1', anchor: true }, error: null }));
+  const select = vi.fn(() => ({ single }));
+  const eq2 = vi.fn(() => ({ select }));
+  const eq1 = vi.fn(() => ({ eq: eq2 }));
+  const update = vi.fn(() => ({ eq: eq1 }));
+  const from = vi.fn(() => ({ update }));
+  return { supabaseClient: { from } };
+});
+
+vi.mock('./ceStudentService', () => {
+  return {
+    studentService: {
+      update: vi.fn(() => Promise.resolve({ id: 'student1', anchor: true })),
+      mapJson: vi.fn()
+    }
+  };
+});
+
+import { placementService } from './cePlacementService';
+import { studentService } from './ceStudentService';
+
+class PlacementFixture {
+  async runUpdate() {
+    return placementService.updatePlacement('plan1', 'student1', { anchor: true });
+  }
+
+  assertStudentUpdated() {
+    expect((studentService.update as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect((studentService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('student1');
+    expect((studentService.update as ReturnType<typeof vi.fn>).mock.calls[0][1]).toEqual({ anchor: true });
+  }
+}
+
+describe('cePlacementService', () => {
+  const fixture = new PlacementFixture();
+
+  it('propagates anchor to student when updatePlacement is called with anchor', async () => {
+    const res = await fixture.runUpdate();
+    // placement update should return the mocked data
+    expect(res.plan_id).toBe('plan1');
+
+    // studentService.update should have been called to propagate anchor
+    fixture.assertStudentUpdated();
+  });
+});

--- a/src/api/cePlacementService.ts
+++ b/src/api/cePlacementService.ts
@@ -105,6 +105,16 @@ class CEPlacementService {
         console.error(SERVICE_ERRORS.ERROR_UPDATING_ENTITY, error.message);
         throw new Error(SERVICE_ERRORS.FAILED_UPDATE_ENTITY);
       }
+      // If the placement's anchor flag was changed, propagate the change to the student record
+      // placement's anchor state -> update student's anchor state
+      if (typeof json.anchor !== 'undefined') {
+        try {
+          await studentService.update(studentId, { anchor: json.anchor });
+        } catch (err) {
+          // Log but do not fail placement update if student update fails
+          console.error('Failed to propagate placement.anchor to student.anchor', err);
+        }
+      }
       return data as unknown as Placement;
     } catch (err) {
       console.error(SERVICE_ERRORS.UNEXPECTED_ERROR_UPDATE, err);

--- a/src/components/StudentCard.tsx
+++ b/src/components/StudentCard.tsx
@@ -19,6 +19,7 @@ import {
 import { RefreshContext } from "@digitalaidseattle/core";
 import { useContext, useState } from "react";
 import { placementService } from "../api/cePlacementService";
+import { PlanContext } from "../pages/plan/PlanContext";
 import { timeWindowService } from "../api/ceTimeWindowService";
 import { Placement } from "../api/types";
 import StarAvatar from "./StarAvatar";
@@ -33,14 +34,53 @@ export const StudentCard: React.FC<{ placement: Placement, showDetails: boolean 
 
     const timeWindows = placement.student!.timeWindows ? placement.student!.timeWindows ?? [] : [];
 
+    const { plan, setPlan } = useContext(PlanContext);
+
     const toggleAnchor = async (placement: Placement) => {
-        placementService
-            .updatePlacement(
+        if (!plan) {
+            // no plan in context - fallback to server update
+            try {
+                await placementService.updatePlacement(
+                    placement.plan_id,
+                    placement.student_id,
+                    { anchor: !placement.anchor });
+                setRefresh(refresh + 1);
+            } catch (error) {
+                console.error(SERVICE_ERRORS.ERROR_TOGGLING_ANCHOR, error)
+            }
+            return;
+        }
+
+        // Optimistic update: update plan in-place so UI doesn't re-fetch and reorder placements
+        const originalPlan = plan;
+        const updatedPlan = {
+            ...plan,
+            placements: plan.placements.map(p =>
+                p.plan_id === placement.plan_id && p.student_id === placement.student_id
+                    ? { ...p, anchor: !p.anchor }
+                    : p
+            )
+        };
+
+        try {
+            setPlan(updatedPlan);
+
+            await placementService.updatePlacement(
                 placement.plan_id,
                 placement.student_id,
-                { anchor: !placement.anchor })
-            .then(() => setRefresh(refresh + 1))
-            .catch((error) => console.error(SERVICE_ERRORS.ERROR_TOGGLING_ANCHOR, error))
+                { anchor: !placement.anchor });
+
+            // success: no further action needed (student propagation handled server-side)
+        } catch (error) {
+            // revert optimistic update on error
+            try {
+                setPlan(originalPlan);
+            } catch (e) {
+                // ignore
+            }
+            console.error(SERVICE_ERRORS.ERROR_TOGGLING_ANCHOR, error)
+            setRefresh(refresh + 1);
+        }
     };
 
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {

--- a/src/pages/cohort/StudentTable.tsx
+++ b/src/pages/cohort/StudentTable.tsx
@@ -103,19 +103,24 @@ export const StudentTable: React.FC = () => {
 
 
   const toggleAnchor = async (enrollment: Enrollment) => {
+    // Optimistically update UI so the change persists across pagination
+    const originalRows = pageInfo.rows;
+    const updatedRows = pageInfo.rows.map((r) =>
+      r.student_id === enrollment.student_id ? { ...r, anchor: !r.anchor } : r
+    );
+
     try {
-      enrollment.anchor = !enrollment.anchor;
-      enrollmentService
-        .updateEnrollment(enrollment.cohort_id, enrollment.student_id, { anchor: enrollment.anchor })
-        .then(() => {
-          // Optimistically update the pageInfo
-          setRefresh(refresh + 1);
-        });
+      setPageInfo({ ...pageInfo, rows: updatedRows });
+
+      await enrollmentService.updateEnrollment(enrollment.cohort_id, enrollment.student_id, { anchor: !enrollment.anchor });
+
+      // trigger a refresh to sync any other derived state
+      setRefresh(refresh + 1);
     } catch (error) {
       console.error(SERVICE_ERRORS.ERROR_TOGGLING_ANCHOR, error);
       notifications.error(UI_STRINGS.FAILED_UPDATE_ANCHOR);
-      // Revert optimistic update
-      setPageInfo({ ...pageInfo });
+      // Revert optimistic update on error
+      setPageInfo({ ...pageInfo, rows: originalRows });
     }
   };
 
@@ -244,6 +249,7 @@ export const StudentTable: React.FC = () => {
 
             pageSizeOptions={[5, 10, 25, 100]}
             checkboxSelection
+            rowSelectionModel={rowSelectionModel}
             onRowSelectionModelChange={setRowSelectionModel}
             disableRowSelectionOnClick={true}
           />


### PR DESCRIPTION
## Description

This PR includes

- Persist student anchor toggles across cohort pagination (optimistic update).
- MUST: propagate placement.anchor → student.anchor on placement update.
- Add unit test verifying placement→student propagation.


https://github.com/user-attachments/assets/bbfa58b8-ac65-4244-bba8-e9478d40ab55


propagate placement.anchor → student.anchor

https://github.com/user-attachments/assets/8dbda9bb-e302-4a4a-a6a0-a70d8a5a9006



## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents



- Related Issue # https://digital-aid-seattle.atlassian.net/browse/CEMT-77
- Closes # https://digital-aid-seattle.atlassian.net/browse/CEMT-77

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well as any relevant images for UI changes._

