### PR TITLE
CEMT-138: Cohort-level student upload

### DIFF
--- a/src/pages/cohort/StudentTable.tsx
+++ b/src/pages/cohort/StudentTable.tsx
@@ -43,7 +43,6 @@ import { addStudentsToCohort } from "../../services/cohort/addStudentsToCohort";
 import { CohortUploadResult, uploadStudentsToCohort } from "../../services/cohort/uploadStudentsToCohort";
 import { CEEnrollmentService } from "../../services/ceEnrollmentService";
 
-
 export const StudentTable: React.FC = () => {
   const studentDao = CEStudentDao.getInstance();
   const enrollmentService = CEEnrollmentService.getInstance();
@@ -64,7 +63,7 @@ export const StudentTable: React.FC = () => {
 
   const [showLocalTime, setShowLocalTime] = useState<boolean>(false);
 
-  // CEMT-138: cohort-level spreadsheet upload state
+  // cohort-level spreadsheet upload state
   const [showDropzone, setShowDropzone] = useState<boolean>(false);
   const [failedProfiles, setFailedProfiles] = useState<FailedProfile[]>([]);
   const [isFailedModalOpen, setIsFailedModalOpen] = useState<boolean>(false);
@@ -101,24 +100,24 @@ export const StudentTable: React.FC = () => {
       })
   }
 
-  // CEMT-138: upload a student spreadsheet and enroll the created students into this cohort
+  // Upload a student spreadsheet and enroll the created students into this cohort.
   async function handleUpload(files: File[]): Promise<void> {
-    uploadStudentsToCohort(cohort, files)
-      .then((result) => displayUploadResults(result))
-      .catch((err) => {
-        console.error('Unexpected Error: ', err);
-        notifications.error(UI_STRINGS.ERROR_ADDING_STUDENTS);
-        setShowDropzone(false);
-      })
-      .finally(() => {
-        setRefresh(refresh + 1);
-      });
+    try {
+      const result = await uploadStudentsToCohort(cohort, files);
+      displayUploadResults(result);
+    } catch (err) {
+      console.error('Unexpected Error: ', err);
+      notifications.error(UI_STRINGS.ERROR_ADDING_STUDENTS);
+      setShowDropzone(false);
+    } finally {
+      setRefresh(refresh + 1);
+    }
   }
 
   function displayUploadResults(resp: CohortUploadResult) {
     setShowDropzone(false);
     if (resp.failedCount === resp.attemptedCount) {
-      notifications.error(`Error uploading spreadsheet. Failed to add ${resp.successCount} of ${resp.attemptedCount}`);
+      notifications.error(`Error uploading spreadsheet. Failed to add all ${resp.attemptedCount} students.`);
       setFailedProfiles(resp.failedProfiles);
       setIsFailedModalOpen(true);
     } else if (resp.failedCount > 0) {

--- a/src/pages/cohort/StudentTable.tsx
+++ b/src/pages/cohort/StudentTable.tsx
@@ -30,14 +30,17 @@ import { PageInfo } from "@digitalaidseattle/supabase";
 
 import { CohortContext } from ".";
 import { CEStudentDao } from "../../api/ceStudentDao";
-import { CEProfile, Enrollment, Student } from "../../api/types";
+import { CEProfile, Enrollment, FailedProfile, Student } from "../../api/types";
 import AddProfileModal from "../../components/AddProfileModal";
 import DisplayTimeWindow from "../../components/DisplayTimeWindow";
+import FailedUploadModal from "../../components/FailedUploadModal";
+import FileUploader from "../../components/FileUploader";
 import { ShowLocalTimeContext } from "../../components/ShowLocalTimeContext";
 import { TimeToggle } from "../../components/TimeToggle";
 import { DEFAULT_TABLE_PAGE_SIZE, SERVICE_ERRORS, UI_STRINGS } from '../../constants';
 import { removeStudentsFromCohort } from "../../services/cohort/removeStudentsFromCohort";
 import { addStudentsToCohort } from "../../services/cohort/addStudentsToCohort";
+import { CohortUploadResult, uploadStudentsToCohort } from "../../services/cohort/uploadStudentsToCohort";
 import { CEEnrollmentService } from "../../api/ceEnrollmentDao";
 
 export const StudentTable: React.FC = () => {
@@ -59,6 +62,11 @@ export const StudentTable: React.FC = () => {
   const [unEnrolled, setUnenrolled] = useState<Student[]>([]);
 
   const [showLocalTime, setShowLocalTime] = useState<boolean>(false);
+
+  // CEMT-138: cohort-level spreadsheet upload state
+  const [showDropzone, setShowDropzone] = useState<boolean>(false);
+  const [failedProfiles, setFailedProfiles] = useState<FailedProfile[]>([]);
+  const [isFailedModalOpen, setIsFailedModalOpen] = useState<boolean>(false);
 
   useEffect(() => {
     setPageInfo({
@@ -90,6 +98,35 @@ export const StudentTable: React.FC = () => {
         notifications.error(UI_STRINGS.ERROR_ADDING_STUDENTS);
         console.error(err);
       })
+  }
+
+  // CEMT-138: upload a student spreadsheet and enroll the created students into this cohort
+  async function handleUpload(files: File[]): Promise<void> {
+    uploadStudentsToCohort(cohort, files)
+      .then((result) => displayUploadResults(result))
+      .catch((err) => {
+        console.error('Unexpected Error: ', err);
+        notifications.error(UI_STRINGS.ERROR_ADDING_STUDENTS);
+        setShowDropzone(false);
+      })
+      .finally(() => {
+        setRefresh(refresh + 1);
+      });
+  }
+
+  function displayUploadResults(resp: CohortUploadResult) {
+    setShowDropzone(false);
+    if (resp.failedCount === resp.attemptedCount) {
+      notifications.error(`Error uploading spreadsheet. Failed to add ${resp.successCount} of ${resp.attemptedCount}`);
+      setFailedProfiles(resp.failedProfiles);
+      setIsFailedModalOpen(true);
+    } else if (resp.failedCount > 0) {
+      setFailedProfiles(resp.failedProfiles);
+      setIsFailedModalOpen(true);
+      notifications.warn(`${resp.attemptedCount} Attempted, ${resp.successCount} added, ${resp.failedCount} failed.`);
+    } else {
+      notifications.success(`${resp.attemptedCount} Attempted, ${resp.successCount} successfully added`);
+    }
   }
 
   const doDelete = () => {
@@ -216,6 +253,13 @@ export const StudentTable: React.FC = () => {
         <Stack direction="row" justifyContent="space-between" alignItems="center">
           <Stack margin={1} gap={1} direction="row" spacing={'1rem'}>
             <Button
+              title={UI_STRINGS.UPLOAD}
+              variant="contained"
+              color="primary"
+              onClick={() => setShowDropzone(!showDropzone)}>
+              {UI_STRINGS.UPLOAD}
+            </Button>
+            <Button
               title={UI_STRINGS.ADD_STUDENT}
               variant="contained"
               color="primary"
@@ -233,6 +277,9 @@ export const StudentTable: React.FC = () => {
           </Stack>
           <TimeToggle />
         </Stack>
+        {showDropzone &&
+          <FileUploader onChange={handleUpload} />
+        }
         {cohort &&
           <DataGrid
             apiRef={apiRef}
@@ -267,6 +314,11 @@ export const StudentTable: React.FC = () => {
           isOpen={showAddStudent}
           onClose={handleCloseStudentModal}
           onSubmit={handleAddStudent} />
+        <FailedUploadModal
+          isModalOpen={isFailedModalOpen}
+          onClose={() => setIsFailedModalOpen(false)}
+          failedProfiles={failedProfiles}
+        />
       </ShowLocalTimeContext.Provider>
     </Box>
   );

--- a/src/services/cohort/uploadStudentsToCohort.test.ts
+++ b/src/services/cohort/uploadStudentsToCohort.test.ts
@@ -1,0 +1,101 @@
+/**
+ *  uploadStudentsToCohort.test.ts
+ *
+ *  @copyright 2026 Digital Aid Seattle
+ *
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Cohort, FailedProfile, Student } from "../../api/types";
+import { StudentUploader } from "../student/StudentUploader";
+import { addStudentsToCohort } from "./addStudentsToCohort";
+import { uploadStudentsToCohort } from "./uploadStudentsToCohort";
+
+vi.mock("../student/StudentUploader", () => {
+    return {
+        StudentUploader: {
+            getInstance: vi.fn(),
+        },
+    };
+});
+
+vi.mock("./addStudentsToCohort", () => {
+    return {
+        addStudentsToCohort: vi.fn(),
+    };
+});
+
+describe("uploadStudentsToCohort", () => {
+    const getInstanceMock = StudentUploader.getInstance as ReturnType<typeof vi.fn>;
+    const addStudentsMock = addStudentsToCohort as ReturnType<typeof vi.fn>;
+
+    const cohort = { id: "cohort1", name: "Test Cohort" } as Cohort;
+
+    // Configure StudentUploader.insert_from_excel to resolve the given
+    // result(s), one per uploaded file, in order.
+    function mockUpload(...results: any[]) {
+        const insert_from_excel = vi.fn();
+        results.forEach(r => insert_from_excel.mockResolvedValueOnce(r));
+        getInstanceMock.mockReturnValue({ insert_from_excel });
+        return insert_from_excel;
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        addStudentsMock.mockResolvedValue(true);
+    });
+
+    it("enrolls every created student into the cohort", async () => {
+        const s1 = { id: "s1", name: "Maria" } as Student;
+        const s2 = { id: "s2", name: "Carlos" } as Student;
+        mockUpload({ successCount: 2, successProfiles: [s1, s2], failedProfiles: [] });
+
+        const result = await uploadStudentsToCohort(cohort, [{} as File]);
+
+        // created students are enrolled in one call
+        expect(addStudentsMock).toHaveBeenCalledTimes(1);
+        expect(addStudentsMock).toHaveBeenCalledWith(cohort, [s1, s2]);
+
+        expect(result.successCount).toBe(2);
+        expect(result.failedCount).toBe(0);
+        expect(result.attemptedCount).toBe(2);
+        expect(result.failedProfiles).toEqual([]);
+    });
+
+    it("does not enroll when no students were created", async () => {
+        const f1 = { name: "Bad1", failedError: "invalid" } as unknown as FailedProfile;
+        const f2 = { name: "Bad2", failedError: "invalid" } as unknown as FailedProfile;
+        mockUpload({ successCount: 0, successProfiles: [], failedProfiles: [f1, f2] });
+
+        const result = await uploadStudentsToCohort(cohort, [{} as File]);
+
+        // a fully failed upload must not trigger an empty enrollment call
+        expect(addStudentsMock).not.toHaveBeenCalled();
+
+        expect(result.successCount).toBe(0);
+        expect(result.failedCount).toBe(2);
+        expect(result.attemptedCount).toBe(2);
+        expect(result.failedProfiles.length).toBe(2);
+    });
+
+    it("aggregates created and failed students across multiple files", async () => {
+        const s1 = { id: "s1", name: "Maria" } as Student;
+        const s2 = { id: "s2", name: "Carlos" } as Student;
+        const f1 = { name: "Bad", failedError: "invalid" } as unknown as FailedProfile;
+        mockUpload(
+            { successCount: 1, successProfiles: [s1], failedProfiles: [f1] },
+            { successCount: 1, successProfiles: [s2], failedProfiles: [] },
+        );
+
+        const result = await uploadStudentsToCohort(cohort, [{} as File, {} as File]);
+
+        // students from both files are enrolled together in a single call
+        expect(addStudentsMock).toHaveBeenCalledTimes(1);
+        expect(addStudentsMock).toHaveBeenCalledWith(cohort, [s1, s2]);
+
+        expect(result.successCount).toBe(2);
+        expect(result.failedCount).toBe(1);
+        expect(result.attemptedCount).toBe(3);
+        expect(result.failedProfiles.length).toBe(1);
+    });
+});

--- a/src/services/cohort/uploadStudentsToCohort.ts
+++ b/src/services/cohort/uploadStudentsToCohort.ts
@@ -1,0 +1,61 @@
+/**
+ *  uploadStudentsToCohort.ts
+ *
+ *  @copyright 2026 Digital Aid Seattle
+ *
+ */
+
+import { Cohort, FailedProfile, Student } from "../../api/types";
+import { SERVICE_ERRORS } from "../../constants";
+import { StudentUploader } from "../student/StudentUploader";
+import { addStudentsToCohort } from "./addStudentsToCohort";
+
+export interface CohortUploadResult {
+    successCount: number;
+    failedProfiles: FailedProfile[];
+    failedCount: number;
+    attemptedCount: number;
+}
+
+/**
+ * CEMT-138
+ *
+ * Uploads one or more student spreadsheets and enrolls every successfully
+ * created student into the given cohort, in a single step.
+ *
+ * Students are still added to the global Student database (handled by
+ * StudentUploader, same as the Students-page upload). They are then enrolled
+ * into the cohort here via addStudentsToCohort, which also copies each
+ * student's anchor flag onto the new enrollment.
+ */
+export async function uploadStudentsToCohort(cohort: Cohort, files: File[]): Promise<CohortUploadResult> {
+    try {
+        const uploadService = StudentUploader.getInstance();
+
+        const responses = await Promise.all(
+            files.map(file => uploadService.insert_from_excel(file))
+        );
+
+        const createdStudents: Student[] = [];
+        let failedProfiles: FailedProfile[] = [];
+        responses.forEach(resp => {
+            createdStudents.push(...resp.successProfiles);
+            failedProfiles = failedProfiles.concat(resp.failedProfiles);
+        });
+
+        // Enroll every created student into this cohort.
+        if (createdStudents.length > 0) {
+            await addStudentsToCohort(cohort, createdStudents);
+        }
+
+        return {
+            successCount: createdStudents.length,
+            failedProfiles: failedProfiles,
+            failedCount: failedProfiles.length,
+            attemptedCount: createdStudents.length + failedProfiles.length,
+        };
+    } catch (err) {
+        console.error(SERVICE_ERRORS.UNEXPECTED_ERROR_SELECT, err);
+        throw err;
+    }
+}

--- a/src/services/plan/ProfileUploader.ts
+++ b/src/services/plan/ProfileUploader.ts
@@ -71,7 +71,7 @@ abstract class ProfileUploader<T extends CEProfile> {
 
     }
 
-    async insert_from_excel(excel_file: File): Promise<{ successCount: number; failedProfiles: FailedProfile[] }> {
+    async insert_from_excel(excel_file: File): Promise<{ successCount: number; successProfiles: T[]; failedProfiles: FailedProfile[] }> {
         try {
             return this.get_profiles_from_excel(excel_file)
                 .then(async profiles => {
@@ -82,6 +82,8 @@ abstract class ProfileUploader<T extends CEProfile> {
                             const failed = resps.filter(resp => !resp.success);
                             return {
                                 successCount: successful.length,
+                                // CEMT-138: expose the created profiles so callers (e.g. cohort upload) can enroll them
+                                successProfiles: successful.map(resp => resp.profile as T),
                                 failedProfiles: failed.map(resp => resp.profile as FailedProfile),
                             }
                         })


### PR DESCRIPTION
## Description

_Adds an Upload button to the cohort Students tab. Uploaded students are created in the global Student table and enrolled into the cohort in one action, via a new `uploadStudentsToCohort` service that runs the existing `StudentUploader` then enrolls the created students through `addStudentsToCohort`._

_The Students-page upload and `createCohort` are unchanged, consistent with the team decision to add in both places and remove later if needed. Anchor flows from the spreadsheet column through to the enrollment record. Includes vitest coverage for the new service._

_Known caveat: uploaded students will not display availabilities until the existing "time windows not showing after upload" bug (Ann raised in standup) is fixed. Out of scope for this PR._

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue # CEMT-132
- Closes # CEMT-138

## QA Instructions, Screenshots, Recordings

1. Open a cohort, Students tab.
2. Click Upload, drop a valid student spreadsheet.
3. Expect a success notification, students populate the grid, and any rows marked anchor in the spreadsheet show the green star.
4. Confirm the Students-page upload and Add Student / Remove Student flows still work as before.

Local setup note: student creation requires `VITE_IPGEOLOCATION_KEY` set in `.env.local` for the timezone lookup. Pre-existing dependency, not introduced by this PR.