### PR TITLE
CEMT-132: Stamp owner id on uploaded time windows

### DIFF
--- a/src/api/ceTimeWindowDao.ts
+++ b/src/api/ceTimeWindowDao.ts
@@ -50,6 +50,23 @@ class CETimeWindowDao extends SupabaseDao<TimeWindow> {
     }
   }
 
+  async deleteByStudentId(studentId: Identifier): Promise<boolean> {
+    try {
+      const { error } = await this.client
+        .from(this.tableName)
+        .delete()
+        .eq('student_id', studentId);
+      if (error) {
+        console.error(SERVICE_ERRORS.ERROR_DELETING_ENTITY, error.message);
+        throw new Error(SERVICE_ERRORS.FAILED_DELETE_ENTITY);
+      }
+      return true;
+    } catch (err) {
+      console.error(SERVICE_ERRORS.UNEXPECTED_ERROR_DELETION, err);
+      throw err;
+    }
+  }
+
 }
 
 export { CETimeWindowDao };

--- a/src/pages/students/StudentsDetailsTable.tsx
+++ b/src/pages/students/StudentsDetailsTable.tsx
@@ -107,7 +107,7 @@ const StudentsDetailsTable: React.FC = () => {
 
   function doDeleteStudent() {
     if (deleteStudent) {
-      studentDao.delete(deleteStudent.id!)
+      studentService.delete(deleteStudent.id!)
         .then(() => {
           notifications.success(`${UI_STRINGS.DELETION_SUCCESS_PREFIX} ${deleteStudent.name} ${UI_STRINGS.DELETION_SUCCESS_SUFFIX}`);
           setRefresh(refresh + 1);

--- a/src/services/ceProfileService.test.ts
+++ b/src/services/ceProfileService.test.ts
@@ -1,0 +1,111 @@
+/**
+ *  ceProfileService.test.ts
+ *
+ *  Regression coverage for CEMT-132: uploaded time windows were saved without an
+ *  owner id, so the deep join keyed on student_id could never load them back, and
+ *  the UI showed "not assigned". CEProfileService.save must stamp the saved
+ *  profile's id onto every time window before insert.
+ *
+ *  @copyright 2026 Digital Aid Seattle
+ *
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Facilitator, Student, TimeWindow } from "../api/types";
+import { CEStudentService } from "./student/CEStudentService";
+import { CEFacilitatorService } from "./facilitator/CEFacilitatorService";
+
+// Spies are declared via vi.hoisted so they exist when the vi.mock factories run.
+const { batchInsertSpy, adjustSpy } = vi.hoisted(() => ({
+    batchInsertSpy: vi.fn(),
+    adjustSpy: vi.fn()
+}));
+
+// Stub the time-window DAO so getInstance does not need a configured Supabase
+// client, and so we can inspect exactly what gets inserted.
+vi.mock("../api/ceTimeWindowDao", () => ({
+    CETimeWindowDao: {
+        getInstance: () => ({ batchInsert: batchInsertSpy })
+    }
+}));
+
+// adjustTimeWindows is irrelevant to this assertion; stub it out.
+vi.mock("./time/ceTimeWindowService", () => ({
+    CETimeWindowService: {
+        getInstance: () => ({ adjustTimeWindows: adjustSpy })
+    }
+}));
+
+// Stub the profile DAOs. upsert echoes the profile so inserted.id === profile.id.
+vi.mock("../api/ceStudentDao", () => ({
+    CEStudentDao: {
+        getInstance: () => ({
+            upsert: vi.fn(async (profile: any) => ({ ...profile })),
+            getById: vi.fn(async (id: any) => ({ id }))
+        })
+    }
+}));
+
+vi.mock("../api/ceFacilitatorDao", () => ({
+    CEFacilitatorDao: {
+        getInstance: () => ({
+            upsert: vi.fn(async (profile: any) => ({ ...profile })),
+            getById: vi.fn(async (id: any) => ({ id }))
+        })
+    }
+}));
+
+// Stub the timezone lookup so the student save does not hit the network.
+vi.mock("./time/ceTimeZoneService", () => ({
+    CETimeZoneService: {
+        getInstance: () => ({
+            getTimeZone: vi.fn(async () => ({ timezone: "America/Los_Angeles", offset: -8 }))
+        })
+    }
+}));
+
+describe("CEProfileService.save owner stamping (CEMT-132)", () => {
+
+    beforeEach(() => {
+        batchInsertSpy.mockClear();
+        adjustSpy.mockClear();
+    });
+
+    it("stamps student_id on every time window it saves", async () => {
+        const student = {
+            id: "student-1",
+            name: "Test Student",
+            city: "Manila",
+            country: "Philippines",
+            timeWindows: [
+                { day_in_week: "Friday", start_t: "07:00:00", end_t: "12:00:00" } as TimeWindow,
+                { day_in_week: "Saturday", start_t: "12:00:00", end_t: "17:00:00" } as TimeWindow
+            ]
+        } as Student;
+
+        await CEStudentService.getInstance().save(student);
+
+        expect(batchInsertSpy).toHaveBeenCalledTimes(1);
+        const inserted = batchInsertSpy.mock.calls[0][0] as TimeWindow[];
+        expect(inserted).toHaveLength(2);
+        inserted.forEach(tw => expect(tw.student_id).toBe("student-1"));
+    });
+
+    it("stamps facilitator_id on every time window it saves", async () => {
+        const facilitator = {
+            id: "facilitator-1",
+            name: "Test Facilitator",
+            timeWindows: [
+                { day_in_week: "Sunday", start_t: "17:00:00", end_t: "22:00:00" } as TimeWindow
+            ]
+        } as Facilitator;
+
+        await CEFacilitatorService.getInstance().save(facilitator);
+
+        expect(batchInsertSpy).toHaveBeenCalledTimes(1);
+        const inserted = batchInsertSpy.mock.calls[0][0] as TimeWindow[];
+        expect(inserted).toHaveLength(1);
+        expect(inserted[0].facilitator_id).toBe("facilitator-1");
+    });
+
+});

--- a/src/services/ceProfileService.test.ts
+++ b/src/services/ceProfileService.test.ts
@@ -16,16 +16,18 @@ import { CEStudentService } from "./student/CEStudentService";
 import { CEFacilitatorService } from "./facilitator/CEFacilitatorService";
 
 // Spies are declared via vi.hoisted so they exist when the vi.mock factories run.
-const { batchInsertSpy, adjustSpy } = vi.hoisted(() => ({
+const { batchInsertSpy, adjustSpy, deleteByStudentIdSpy, studentDaoDeleteSpy } = vi.hoisted(() => ({
     batchInsertSpy: vi.fn(),
-    adjustSpy: vi.fn()
+    adjustSpy: vi.fn(),
+    deleteByStudentIdSpy: vi.fn(async () => true),
+    studentDaoDeleteSpy: vi.fn(async () => undefined)
 }));
 
 // Stub the time-window DAO so getInstance does not need a configured Supabase
 // client, and so we can inspect exactly what gets inserted.
 vi.mock("../api/ceTimeWindowDao", () => ({
     CETimeWindowDao: {
-        getInstance: () => ({ batchInsert: batchInsertSpy })
+        getInstance: () => ({ batchInsert: batchInsertSpy, deleteByStudentId: deleteByStudentIdSpy })
     }
 }));
 
@@ -41,7 +43,8 @@ vi.mock("../api/ceStudentDao", () => ({
     CEStudentDao: {
         getInstance: () => ({
             upsert: vi.fn(async (profile: any) => ({ ...profile })),
-            getById: vi.fn(async (id: any) => ({ id }))
+            getById: vi.fn(async (id: any) => ({ id })),
+            delete: studentDaoDeleteSpy
         })
     }
 }));
@@ -69,6 +72,8 @@ describe("CEProfileService.save owner stamping (CEMT-132)", () => {
     beforeEach(() => {
         batchInsertSpy.mockClear();
         adjustSpy.mockClear();
+        deleteByStudentIdSpy.mockClear();
+        studentDaoDeleteSpy.mockClear();
     });
 
     it("stamps student_id on every time window it saves", async () => {
@@ -106,6 +111,29 @@ describe("CEProfileService.save owner stamping (CEMT-132)", () => {
         const inserted = batchInsertSpy.mock.calls[0][0] as TimeWindow[];
         expect(inserted).toHaveLength(1);
         expect(inserted[0].facilitator_id).toBe("facilitator-1");
+    });
+
+});
+
+describe("CEStudentService.delete (student delete cleanup)", () => {
+
+    beforeEach(() => {
+        deleteByStudentIdSpy.mockClear();
+        studentDaoDeleteSpy.mockClear();
+    });
+
+    it("deletes the student's time windows before the student row", async () => {
+        await CEStudentService.getInstance().delete("student-1");
+
+        expect(deleteByStudentIdSpy).toHaveBeenCalledTimes(1);
+        expect(deleteByStudentIdSpy).toHaveBeenCalledWith("student-1");
+        expect(studentDaoDeleteSpy).toHaveBeenCalledTimes(1);
+        expect(studentDaoDeleteSpy).toHaveBeenCalledWith("student-1");
+
+        // Order matters: timewindow.student_id has no ON DELETE rule, so the
+        // windows must be gone before the student row is deleted.
+        expect(deleteByStudentIdSpy.mock.invocationCallOrder[0])
+            .toBeLessThan(studentDaoDeleteSpy.mock.invocationCallOrder[0]);
     });
 
 });

--- a/src/services/ceProfileService.ts
+++ b/src/services/ceProfileService.ts
@@ -6,7 +6,8 @@
  */
 
 import { v4 as uuid } from 'uuid';
-import { CEProfile } from '../api/types';
+import { Identifier } from '@digitalaidseattle/core';
+import { CEProfile, TimeWindow } from '../api/types';
 import { SupabaseDao } from '../api/SupabaseDao';
 import { CETimeWindowDao } from '../api/ceTimeWindowDao';
 import { CETimeWindowService } from './time/ceTimeWindowService';
@@ -25,6 +26,13 @@ class CEProfileService<T extends CEProfile> {
         throw new Error('Subclass should implement.')
     };
 
+    // Stamp the owning profile's id onto a time window before it is persisted.
+    // Students set student_id; facilitators set facilitator_id.
+    // Subclasses implement this so a window is never saved without an owner.
+    assignOwner(_timeWindow: TimeWindow, _ownerId: Identifier): TimeWindow {
+        throw new Error('Subclass should implement.');
+    }
+
     async save(profile: T): Promise<T> {
         const timeWindowDao = CETimeWindowDao.getInstance();
         const timeWindowService = CETimeWindowService.getInstance();
@@ -39,10 +47,7 @@ class CEProfileService<T extends CEProfile> {
         const inserted = await this.profileDao.upsert(json)
 
         const timeWindows = (profile.timeWindows ?? [])
-            .map(tw => ({
-                ...tw,
-                id: uuid()
-            }));
+            .map(tw => this.assignOwner({ ...tw, id: uuid() } as TimeWindow, inserted.id!));
 
         await timeWindowDao.batchInsert(timeWindows);
 

--- a/src/services/facilitator/CEFacilitatorService.ts
+++ b/src/services/facilitator/CEFacilitatorService.ts
@@ -7,7 +7,8 @@
 
 import { v4 as uuid } from 'uuid';
 
-import { Facilitator } from '../../api/types';
+import { Identifier } from '@digitalaidseattle/core';
+import { Facilitator, TimeWindow } from '../../api/types';
 import { CEFacilitatorDao } from '../../api/ceFacilitatorDao';
 import { CEProfileService } from '../ceProfileService';
 
@@ -41,9 +42,13 @@ class CEFacilitatorService extends CEProfileService<Facilitator> {
             timeWindows: []
         } as Facilitator;
     }
+
+    assignOwner(timeWindow: TimeWindow, ownerId: Identifier): TimeWindow {
+        timeWindow.facilitator_id = ownerId;
+        return timeWindow;
+    }
 }
 
 
 
 export { CEFacilitatorService };
-

--- a/src/services/student/CEStudentService.ts
+++ b/src/services/student/CEStudentService.ts
@@ -8,6 +8,7 @@
 import { v4 as uuid } from 'uuid';
 import { Identifier } from '@digitalaidseattle/core';
 import { CEStudentDao } from '../../api/ceStudentDao';
+import { CETimeWindowDao } from '../../api/ceTimeWindowDao';
 import { GENDER_OPTION, Student, TimeWindow } from '../../api/types';
 import { CEProfileService } from '../ceProfileService';
 import { CETimeZoneService } from '../time/ceTimeZoneService';
@@ -48,6 +49,17 @@ class CEStudentService extends CEProfileService<Student> {
     assignOwner(timeWindow: TimeWindow, ownerId: Identifier): TimeWindow {
         timeWindow.student_id = ownerId;
         return timeWindow;
+    }
+
+    // Delete a student and their time windows.
+    // The windows must be deleted first: timewindow.student_id has no
+    // ON DELETE rule, so the database blocks deleting a student that
+    // still has windows pointing at it. Mirrors the child-rows-first
+    // pattern used by planDelete and ceGroupService.deleteGroup.
+    async delete(studentId: Identifier): Promise<void> {
+        const timeWindowDao = CETimeWindowDao.getInstance();
+        await timeWindowDao.deleteByStudentId(studentId);
+        await this.profileDao.delete(studentId);
     }
 
     async save(profile: Student): Promise<Student> {

--- a/src/services/student/CEStudentService.ts
+++ b/src/services/student/CEStudentService.ts
@@ -6,8 +6,9 @@
  */
 
 import { v4 as uuid } from 'uuid';
+import { Identifier } from '@digitalaidseattle/core';
 import { CEStudentDao } from '../../api/ceStudentDao';
-import { GENDER_OPTION, Student } from '../../api/types';
+import { GENDER_OPTION, Student, TimeWindow } from '../../api/types';
 import { CEProfileService } from '../ceProfileService';
 import { CETimeZoneService } from '../time/ceTimeZoneService';
 
@@ -44,6 +45,11 @@ class CEStudentService extends CEProfileService<Student> {
         } as Student;
     }
 
+    assignOwner(timeWindow: TimeWindow, ownerId: Identifier): TimeWindow {
+        timeWindow.student_id = ownerId;
+        return timeWindow;
+    }
+
     async save(profile: Student): Promise<Student> {
         const { timezone, offset } = await this.timezoneService.getTimeZone(profile.city!, profile.country)
         const updated = {
@@ -58,4 +64,3 @@ class CEStudentService extends CEProfileService<Student> {
 
 
 export { CEStudentService };
-


### PR DESCRIPTION
## Update: also fixes student deletion

Linking time windows to their student (the main fix above) exposed a latent bug: deleting a student then failed with a 409 foreign key violation. The cause is that timewindow.student_id has no ON DELETE rule (unlike facilitator_id and assignment_id, which are ON DELETE SET NULL), and the delete path removed only the student row.

Without this, merging the time window fix would have made students undeletable after upload.

Changes:
- CETimeWindowDao: new deleteByStudentId, mirroring deleteByGroupId
- CEStudentService: new delete method that removes the student's time windows before the student row, matching the child rows first pattern in planDelete and ceGroupService.deleteGroup
- StudentsDetailsTable: delete now goes through the service instead of the DAO
- New unit test asserting windows are deleted before the student row

Additional QA steps:
1. Upload students, delete one. Expect success, no 409 in the console, and the student's timewindow rows gone.
2. Add a student manually with availability, delete. Same result.

Note: a student enrolled in a cohort still cannot be deleted (enrollment.student_id also has no ON DELETE rule). That is pre-existing behavior, unchanged by this PR, and worth a separate product decision.