### PR TITLE
CEMT-130: refetch cohort in place on refresh to avoid subtree teardown

### DIFF
--- a/src/components/PlanCard.tsx
+++ b/src/components/PlanCard.tsx
@@ -1,4 +1,3 @@
-
 /**
  *  PlanCard.tsx
  *
@@ -32,13 +31,18 @@ export const PlanCard = (props: { planId: Identifier }) => {
 
     const navigate = useNavigate();
 
+    // Refetch the plan on refresh (poll + post-mutation bump) as well as on planId
+    // change, so the card's own state (active star, name, note, counts, durations)
+    // stays current without relying on the parent remounting it. The menu/dialog
+    // state below is plain local state that a re-render does not reset, so open
+    // overlays survive a refresh.
     useEffect(() => {
         if (props.planId) {
             CEPlanDao.getInstance()
                 .getById(props.planId)
                 .then((resp) => setPlan(resp!))
         }
-    }, [props.planId]);
+    }, [props.planId, refresh]);
 
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
         setAnchorEl(event.currentTarget);

--- a/src/components/TextEdit.tsx
+++ b/src/components/TextEdit.tsx
@@ -1,27 +1,29 @@
-
-
 /**
  *  TextEdit.tsx
  *
  *  @copyright 2024 Digital Aid Seattle
  *
  */
-
 import { CheckCircleOutlined, CloseCircleOutlined, EditOutlined } from "@ant-design/icons";
 import { IconButton, Stack, TextField, Typography } from "@mui/material";
 import { useState } from "react";
-
 export type TextEditProps = {
     label: string,
     value: string,
     rows?: number,
     onChange: (text: string) => void
 };
-
 export const TextEdit: React.FC<TextEditProps> = ({ label, value, rows, onChange }) => {
     const [edit, setEdit] = useState<boolean>(false);
+    // `text` is only an edit scratch buffer. The read view renders `value`
+    // directly, so an external change to the prop (e.g. another user's rename
+    // arriving via refresh) is reflected immediately. The buffer is seeded from
+    // `value` when entering edit mode, so in-progress typing is never clobbered.
     const [text, setText] = useState<string>(value);
-
+    const startEdit = () => {
+        setText(value);
+        setEdit(true);
+    }
     const cancel = () => {
         setText(value);
         setEdit(false);
@@ -30,14 +32,13 @@ export const TextEdit: React.FC<TextEditProps> = ({ label, value, rows, onChange
         onChange(text)
         setEdit(false);
     }
-
     return (
         <>
             <Stack direction={'row'}>
                 <Typography fontWeight={600} sx={{ marginRight: 2 }} >{label}:</Typography>
                 {!edit && <>
-                    <Typography sx={{ marginRight: 2 }}>{text}</Typography>
-                    <IconButton size="small" color="primary" onClick={() => setEdit(!edit)}>
+                    <Typography sx={{ marginRight: 2 }}>{value}</Typography>
+                    <IconButton size="small" color="primary" onClick={startEdit}>
                         <EditOutlined />
                     </IconButton>
                 </>
@@ -65,4 +66,3 @@ export const TextEdit: React.FC<TextEditProps> = ({ label, value, rows, onChange
             </Stack>
         </>)
 }
-

--- a/src/pages/cohort/index.tsx
+++ b/src/pages/cohort/index.tsx
@@ -2,11 +2,11 @@
  * CohortPage.tsx
  *
  * Example of integrating tickets with data-grid
- * 
+ *
  * @copyright 2026 Digital Aid Seattle
  */
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 
 // material-ui
@@ -47,9 +47,11 @@ const CohortPage: React.FC = () => {
   const [cohort, setCohort] = useState<Cohort | null>();
   const [tabValue, setTabValue] = useState<number>(0);
 
-  useEffect(() => {
+  const loadCohort = (clearFirst: boolean) => {
     if (cohortId) {
-      setCohort(undefined);
+      if (clearFirst) {
+        setCohort(undefined);
+      }
       cohortDao.getById(cohortId)
         .then((cohort) => {
           if (cohort) {
@@ -59,7 +61,26 @@ const CohortPage: React.FC = () => {
           }
         });
     }
-  }, [cohortId, refresh]);
+  };
+
+  // Initial load and cohort switch: clear first so a stale cohort never flashes
+  // while the new one loads.
+  useEffect(() => {
+    loadCohort(true);
+  }, [cohortId]);
+
+  // Refresh (manual post-mutation bump and the 10s poll): refetch in place
+  // without clearing, so the subtree is not unmounted and in-progress UI
+  // (open modals, row selections, inline rename) survives. Skip the first run
+  // so mount does not fetch twice.
+  const isFirstRefresh = useRef(true);
+  useEffect(() => {
+    if (isFirstRefresh.current) {
+      isFirstRefresh.current = false;
+      return;
+    }
+    loadCohort(false);
+  }, [refresh]);
 
   useEffect(() => {
     if (searchParams && searchParams.get('tab')) {


### PR DESCRIPTION
Fixes CEMT-130 and CEMT-131 (marked as the same issue).

Problem
On the cohort detail page, the 10 second auto refresh poll interrupted in progress interactions. While selecting students in the Add Student modal, or selecting rows for Remove Student, the selections were wiped every 10 seconds. The same teardown also discarded an in progress cohort name rename and open plan card menus.

Cause
The cohort load effect in src/pages/cohort/index.tsx ran on every refresh, including the 10 second poll, and called setCohort(undefined) before refetching. Because the page renders behind a cohort && (...) gate, nulling the cohort unmounted the entire subtree (StudentTable, the open modal, the rename editor) and destroyed their local state. On refetch the subtree remounted fresh, so any unsaved selection or text was lost.

Fix
Split the single load effect into two:
- [cohortId]: clears first then loads, so switching cohorts still shows a clean loading state.
- [refresh]: refetches in place without clearing, so the poll and post mutation refreshes re-render instead of unmounting. A first run guard prevents a duplicate fetch on mount.

This stops the teardown for every affected interaction at once, while preserving refresh after mutation behavior.

Testing
- tsc --noEmit clean.
- Existing unit tests unchanged. The 6 suites that fail locally fail identically on dev due to the missing Supabase client config in the test environment; GitHub Actions is the authoritative run.
- Manually verified on local Supabase: Add Student selections, Remove Student row selections, and cohort rename all survive the 10 second poll after the fix.

Note
The shared @digitalaidseattle/core RefreshContextProvider polls every 10 seconds. This PR addresses the symptom in app code. Removing or gating that poll at the source is a larger cross app change to the shared package and is worth a separate team discussion.