### PR TITLE
CEMT-148: Fix timezone-stable time window tests

### DIFF
--- a/src/services/group/ceGroupService.test.ts
+++ b/src/services/group/ceGroupService.test.ts
@@ -5,16 +5,19 @@
  *
  */
 import { describe, expect, it, vi } from "vitest";
+import { formatInTimeZone } from "date-fns-tz";
 import { CEGroupService } from "./ceGroupService";
 import { CETimeWindowDao } from "../../api/ceTimeWindowDao";
 import { Group, TimeWindow } from "../../api/types";
 import { CEGroupDao } from "../../api/ceGroupDao";
+import { DEFAULT_TIMEZONE } from "../time/ceTimeWindowService";
 
 describe("groupService", () => {
-    const offset = -7; // using a fixed offset to make test deterministic; 
     const groupService = CEGroupService.getInstance();
     const groupDao = CEGroupDao.getInstance();
     const timeWindowDao = CETimeWindowDao.getInstance();
+    const formatDefaultTimeZone = (date: Date) =>
+        formatInTimeZone(date, DEFAULT_TIMEZONE, "EEE H");
 
     it("createDefaultTimewindows", () => {
 
@@ -25,12 +28,9 @@ describe("groupService", () => {
         const result = groupService.createDefaultTimewindows(group)
 
         expect(result.length).toBe(3);
-        expect(result[0].start_date_time.getDay()).toBe(5);
-        expect(result[0].start_date_time.getHours()).toBe(7);
-        expect(result[0].start_date_time.getUTCHours()).toBe(7 - offset);
-        expect(result[2].end_date_time.getDay()).toBe(0);
-        expect(result[2].end_date_time.getHours()).toBe(22);
-
+        expect(formatDefaultTimeZone(result[0].start_date_time)).toBe("Fri 7");
+        expect(formatDefaultTimeZone(result[2].end_date_time)).toBe("Sun 22");
+        
     });
 
     it("deleteGroup", () => {

--- a/src/services/time/ceTimeWindowService-union-merge.test.ts
+++ b/src/services/time/ceTimeWindowService-union-merge.test.ts
@@ -10,13 +10,13 @@ describe("timeWindowService", () => {
 
     it("union, 'AS', 'AE', 'BS', 'BE' - none", () => {
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "10:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "10:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "13:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "13:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.unionTimeWindows(timeA, timeB);
@@ -30,13 +30,13 @@ describe("timeWindowService", () => {
 
     it("union, 'AS', 'AE', 'BS', 'BE' - union", () => {
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "13:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "13:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.unionTimeWindows(timeA, timeB);
@@ -49,13 +49,13 @@ describe("timeWindowService", () => {
     it("union, 'AS', 'BS', 'BE', 'AE' - overlap", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "17:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "17:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.unionTimeWindows(timeA, timeB);
@@ -68,13 +68,13 @@ describe("timeWindowService", () => {
     it("union, 'BS', 'BE', 'AS', 'AE' - overlap", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.unionTimeWindows(timeA, timeB);
@@ -87,13 +87,13 @@ describe("timeWindowService", () => {
     it("union, 'BS', 'BE', 'AS', 'AE' - none", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "16:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "18:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "16:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "18:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const union = timeWindowService.unionTimeWindows(timeA, timeB);
@@ -108,13 +108,13 @@ describe("timeWindowService", () => {
     it("union, different day - none", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(1, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(1, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(1, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(1, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const union = timeWindowService.unionTimeWindows(timeA, timeB);
@@ -129,8 +129,8 @@ describe("timeWindowService", () => {
     it("merge - small", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.mergeTimeWindows([timeA]);
@@ -144,13 +144,13 @@ describe("timeWindowService", () => {
     it("merge - two", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "18:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "18:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.mergeTimeWindows([timeA, timeB]);
@@ -164,18 +164,18 @@ describe("timeWindowService", () => {
     it("merge - back2back2back", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "18:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "18:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeC = {
-            start_date_time: timeWindowService.toZonedTime(0, "18:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "20:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "18:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "20:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.mergeTimeWindows([timeA, timeB, timeC]);
@@ -189,18 +189,18 @@ describe("timeWindowService", () => {
     it("merge - three", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "18:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "18:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeC = {
-            start_date_time: timeWindowService.toZonedTime(1, "14:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(1, "18:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(1, "14:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(1, "18:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.mergeTimeWindows([timeA, timeB, timeC]);

--- a/src/services/time/ceTimeWindowService-union-merge.test.ts
+++ b/src/services/time/ceTimeWindowService-union-merge.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { formatInTimeZone } from "date-fns-tz";
 import { TimeWindow } from "../../api/types";
 import { CETimeWindowService, DEFAULT_TIMEZONE } from "./ceTimeWindowService";
 
 describe("timeWindowService", () => {
     const timeWindowService = CETimeWindowService.getInstance();
+    const hourInDefaultTimeZone = (date: Date) =>
+        Number(formatInTimeZone(date, DEFAULT_TIMEZONE, "H"));
 
     it("union, 'AS', 'AE', 'BS', 'BE' - none", () => {
         const timeA = {
@@ -19,10 +22,10 @@ describe("timeWindowService", () => {
         const merged = timeWindowService.unionTimeWindows(timeA, timeB);
         expect(merged).toBeDefined();
         expect(merged.length).toBe(2);
-        expect(merged[0].start_date_time?.getHours()).toBe(8);
-        expect(merged[0].end_date_time?.getHours()).toBe(10);
-        expect(merged[1].start_date_time?.getHours()).toBe(12);
-        expect(merged[1].end_date_time?.getHours()).toBe(13);
+        expect(hourInDefaultTimeZone(merged[0].start_date_time)).toBe(8);
+        expect(hourInDefaultTimeZone(merged[0].end_date_time)).toBe(10);
+        expect(hourInDefaultTimeZone(merged[1].start_date_time)).toBe(12);
+        expect(hourInDefaultTimeZone(merged[1].end_date_time)).toBe(13);
     });
 
     it("union, 'AS', 'AE', 'BS', 'BE' - union", () => {
@@ -39,8 +42,8 @@ describe("timeWindowService", () => {
         const merged = timeWindowService.unionTimeWindows(timeA, timeB);
         expect(merged).toBeDefined();
         expect(merged.length).toBe(1);
-        expect(merged[0].start_date_time?.getHours()).toBe(8);
-        expect(merged[0].end_date_time?.getHours()).toBe(13);
+        expect(hourInDefaultTimeZone(merged[0].start_date_time)).toBe(8);
+        expect(hourInDefaultTimeZone(merged[0].end_date_time)).toBe(13);
     });
 
     it("union, 'AS', 'BS', 'BE', 'AE' - overlap", () => {
@@ -58,8 +61,8 @@ describe("timeWindowService", () => {
         const merged = timeWindowService.unionTimeWindows(timeA, timeB);
         expect(merged).toBeDefined();
         expect(merged.length).toBe(1);
-        expect(merged[0].start_date_time?.getHours()).toBe(8);
-        expect(merged[0].end_date_time?.getHours()).toBe(17);
+        expect(hourInDefaultTimeZone(merged[0].start_date_time)).toBe(8);
+        expect(hourInDefaultTimeZone(merged[0].end_date_time)).toBe(17);
     });
 
     it("union, 'BS', 'BE', 'AS', 'AE' - overlap", () => {
@@ -77,8 +80,8 @@ describe("timeWindowService", () => {
         const merged = timeWindowService.unionTimeWindows(timeA, timeB);
         expect(merged).toBeDefined();
         expect(merged.length).toBe(1);
-        expect(merged[0].start_date_time?.getHours()).toBe(8);
-        expect(merged[0].end_date_time?.getHours()).toBe(14);
+        expect(hourInDefaultTimeZone(merged[0].start_date_time)).toBe(8);
+        expect(hourInDefaultTimeZone(merged[0].end_date_time)).toBe(14);
     });
 
     it("union, 'BS', 'BE', 'AS', 'AE' - none", () => {
@@ -96,10 +99,10 @@ describe("timeWindowService", () => {
         const union = timeWindowService.unionTimeWindows(timeA, timeB);
         expect(union).toBeDefined();
         expect(union.length).toBe(2);
-        expect(union[0].start_date_time?.getHours()).toBe(12);
-        expect(union[0].end_date_time?.getHours()).toBe(14);
-        expect(union[1].start_date_time?.getHours()).toBe(16);
-        expect(union[1].end_date_time?.getHours()).toBe(18);
+        expect(hourInDefaultTimeZone(union[0].start_date_time)).toBe(12);
+        expect(hourInDefaultTimeZone(union[0].end_date_time)).toBe(14);
+        expect(hourInDefaultTimeZone(union[1].start_date_time)).toBe(16);
+        expect(hourInDefaultTimeZone(union[1].end_date_time)).toBe(18);
     });
 
     it("union, different day - none", () => {
@@ -117,10 +120,10 @@ describe("timeWindowService", () => {
         const union = timeWindowService.unionTimeWindows(timeA, timeB);
         expect(union).toBeDefined();
         expect(union.length).toBe(2);
-        expect(union[0].start_date_time?.getHours()).toBe(8);
-        expect(union[0].end_date_time?.getHours()).toBe(14);
-        expect(union[1].start_date_time?.getHours()).toBe(8);
-        expect(union[1].end_date_time?.getHours()).toBe(14);
+        expect(hourInDefaultTimeZone(union[0].start_date_time)).toBe(8);
+        expect(hourInDefaultTimeZone(union[0].end_date_time)).toBe(14);
+        expect(hourInDefaultTimeZone(union[1].start_date_time)).toBe(8);
+        expect(hourInDefaultTimeZone(union[1].end_date_time)).toBe(14);
     });
 
     it("merge - small", () => {
@@ -134,8 +137,8 @@ describe("timeWindowService", () => {
 
         expect(merged).toBeDefined();
         expect(merged.length).toBe(1);
-        expect(merged[0].start_date_time?.getHours()).toBe(12);
-        expect(merged[0].end_date_time?.getHours()).toBe(14);
+        expect(hourInDefaultTimeZone(merged[0].start_date_time)).toBe(12);
+        expect(hourInDefaultTimeZone(merged[0].end_date_time)).toBe(14);
     });
 
     it("merge - two", () => {
@@ -154,8 +157,8 @@ describe("timeWindowService", () => {
 
         expect(merged).toBeDefined();
         expect(merged.length).toBe(1);
-        expect(merged[0].start_date_time?.getHours()).toBe(12);
-        expect(merged[0].end_date_time?.getHours()).toBe(18);
+        expect(hourInDefaultTimeZone(merged[0].start_date_time)).toBe(12);
+        expect(hourInDefaultTimeZone(merged[0].end_date_time)).toBe(18);
     });
 
     it("merge - back2back2back", () => {
@@ -179,8 +182,8 @@ describe("timeWindowService", () => {
 
         expect(merged).toBeDefined();
         expect(merged.length).toBe(1);
-        expect(merged[0].start_date_time?.getHours()).toBe(12);
-        expect(merged[0].end_date_time?.getHours()).toBe(20);
+        expect(hourInDefaultTimeZone(merged[0].start_date_time)).toBe(12);
+        expect(hourInDefaultTimeZone(merged[0].end_date_time)).toBe(20);
     });
 
     it("merge - three", () => {
@@ -204,8 +207,8 @@ describe("timeWindowService", () => {
 
         expect(merged).toBeDefined();
         expect(merged.length).toBe(2);
-        expect(merged[0].start_date_time?.getHours()).toBe(12);
-        expect(merged[0].end_date_time?.getHours()).toBe(18);
+        expect(hourInDefaultTimeZone(merged[0].start_date_time)).toBe(12);
+        expect(hourInDefaultTimeZone(merged[0].end_date_time)).toBe(18);
     });
 
 });

--- a/src/services/time/ceTimeWindowService.test.ts
+++ b/src/services/time/ceTimeWindowService.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { formatInTimeZone } from "date-fns-tz";
 import { DEFAULT_TIMEZONE, CETimeWindowService } from "./ceTimeWindowService";
 import { TimeWindow } from "../../api/types";
 
 describe("timeWindowService", () => {
     const timeWindowService = CETimeWindowService.getInstance();
-    const offset = -7; // using a fixed offset to make test deterministic;
-    // getTimezoneOffset(DEFAULT_TIMEZONE, new Date()) / 60 / 60 / 1000;
+    const formatTimeWindow = (date: Date, timezone = DEFAULT_TIMEZONE) =>
+        formatInTimeZone(date, timezone, "yyyy-MM-dd EEE H");
 
     it("toString", () => {
         const tw = {
@@ -18,18 +19,13 @@ describe("timeWindowService", () => {
 
     it("toZonedTime", () => {
         const result = timeWindowService.toZonedTime(0, "07:00:00", DEFAULT_TIMEZONE);
-        expect(result.getDate()).toBe(1);
-        expect(result.getDay()).toBe(5);
-        expect(result.getHours()).toBe(7); // PDT is UTC-7, so 7+7=14
-        expect(result.getUTCHours()).toBe(7 - offset); // PDT is UTC-7, so 7+7=14
+        expect(formatTimeWindow(result)).toBe("2000-09-01 Fri 7");
     });
 
     it("toZonedTime - Mexico_City", () => {
         const result = timeWindowService.toZonedTime(0, "07:00:00", "America/Mexico_City");
-        expect(result.getDate()).toBe(1);
-        expect(result.getDay()).toBe(5);
-        expect(result.getHours()).toBe(9);
-        expect(result.getUTCHours()).toBe(9 - offset); // PDT is UTC-7, so 7+7=14
+        expect(formatTimeWindow(result, "America/Mexico_City")).toBe("2000-09-01 Fri 7");
+        expect(formatTimeWindow(result, DEFAULT_TIMEZONE)).toBe("2000-09-01 Fri 5");
     });
 
     it("intersectionTimeWindows", () => {
@@ -45,9 +41,9 @@ describe("timeWindowService", () => {
         } as TimeWindow;
 
         const merged = timeWindowService.intersectionTimeWindows(timeA, timeB);
-        expect(merged?.start_date_time?.getDay()).toBe(5);
-        expect(merged?.start_date_time?.getHours()).toBe(9);
-        expect(merged?.end_date_time?.getHours()).toBe(12);
+        expect(merged).not.toBeNull();
+        expect(formatTimeWindow(merged!.start_date_time!)).toBe("2000-09-01 Fri 9");
+        expect(formatTimeWindow(merged!.end_date_time!)).toBe("2000-09-01 Fri 12");
 
     });
 

--- a/src/services/time/ceTimeWindowService.test.ts
+++ b/src/services/time/ceTimeWindowService.test.ts
@@ -10,20 +10,20 @@ describe("timeWindowService", () => {
 
     it("toString", () => {
         const tw = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "14:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "14:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow
         const result = timeWindowService.toString(tw);
         expect(result).toBe('Fri 8am - 2pm');
     })
 
     it("toZonedTime", () => {
-        const result = timeWindowService.toZonedTime(0, "07:00:00", DEFAULT_TIMEZONE);
+        const result = timeWindowService.localTimeToUTC(0, "07:00:00", DEFAULT_TIMEZONE);
         expect(formatTimeWindow(result)).toBe("2000-09-01 Fri 7");
     });
 
     it("toZonedTime - Mexico_City", () => {
-        const result = timeWindowService.toZonedTime(0, "07:00:00", "America/Mexico_City");
+        const result = timeWindowService.localTimeToUTC(0, "07:00:00", "America/Mexico_City");
         expect(formatTimeWindow(result, "America/Mexico_City")).toBe("2000-09-01 Fri 7");
         expect(formatTimeWindow(result, DEFAULT_TIMEZONE)).toBe("2000-09-01 Fri 5");
     });
@@ -31,13 +31,13 @@ describe("timeWindowService", () => {
     it("intersectionTimeWindows", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "09:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "13:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "09:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "13:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.intersectionTimeWindows(timeA, timeB);
@@ -50,13 +50,13 @@ describe("timeWindowService", () => {
     it("intersectionTimeWindows - none", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(1, "09:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(1, "13:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(1, "09:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(1, "13:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const merged = timeWindowService.intersectionTimeWindows(timeA, timeB);
@@ -67,8 +67,8 @@ describe("timeWindowService", () => {
     it("duration - count", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const duration = timeWindowService.duration(timeA);
@@ -79,17 +79,31 @@ describe("timeWindowService", () => {
     it("totalDuration", () => {
 
         const timeA = {
-            start_date_time: timeWindowService.toZonedTime(0, "08:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "12:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "08:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "12:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const timeB = {
-            start_date_time: timeWindowService.toZonedTime(0, "010:00:00", DEFAULT_TIMEZONE),
-            end_date_time: timeWindowService.toZonedTime(0, "11:00:00", DEFAULT_TIMEZONE)
+            start_date_time: timeWindowService.localTimeToUTC(0, "010:00:00", DEFAULT_TIMEZONE),
+            end_date_time: timeWindowService.localTimeToUTC(0, "11:00:00", DEFAULT_TIMEZONE)
         } as TimeWindow;
 
         const duration = timeWindowService.totalDuration([timeA, timeB]);
         expect(duration).toBe(7);
 
+    });
+
+    it("adjustTimeWindows - Mexico_City", () => {
+        const timezone = "America/Mexico_City";
+        const friday = { day_in_week: "Friday", start_t: "07:00:00", end_t: "12:00:00" } as TimeWindow;
+        const saturday = { day_in_week: "Saturday", start_t: "09:00:00", end_t: "17:00:00" } as TimeWindow;
+        const profile = { time_zone: timezone, timeWindows: [friday, saturday] } as any;
+
+        timeWindowService.adjustTimeWindows(profile);
+
+        expect(formatTimeWindow(friday.start_date_time, timezone)).toBe("2000-09-01 Fri 7");
+        expect(formatTimeWindow(friday.end_date_time, timezone)).toBe("2000-09-01 Fri 12");
+        expect(formatTimeWindow(saturday.start_date_time, timezone)).toBe("2000-09-02 Sat 9");
+        expect(formatTimeWindow(saturday.end_date_time, timezone)).toBe("2000-09-02 Sat 17");
     });
 });

--- a/src/services/time/ceTimeWindowService.ts
+++ b/src/services/time/ceTimeWindowService.ts
@@ -5,8 +5,8 @@
  *
  */
 
-import { format, isEqual } from "date-fns";
-import { toZonedTime } from "date-fns-tz";
+import { isEqual } from "date-fns";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { v4 as uuid } from 'uuid';
 import { SERVICE_ERRORS } from '../../constants';
 import { CETimeWindowDao } from "../../api/ceTimeWindowDao";
@@ -234,14 +234,17 @@ class CETimeWindowService {
     }
   }
 
-  //  Arbitrairly chose year 2000, September (month 8), and day 1 + dayOffset
+  // Arbitrairly chose year 2000, September (month 8), and day 1 + dayOffset
   // dayOffset is 0 for Friday, 1 for Saturday, and 2 for Sunday
   toZonedTime(dayOffset: number, time: string, timezone: string): Date {
     const sTimes = time
       .split(':')
       .map((s) => Number.parseInt(s));
-    const dateTime = new Date(2000, 8, dayOffset + 1, sTimes[0], sTimes[1], sTimes[2])
-    return toZonedTime(dateTime, timezone);
+    const day = String(dayOffset + 1).padStart(2, '0');
+    const hour = String(sTimes[0]).padStart(2, '0');
+    const minute = String(sTimes[1] ?? 0).padStart(2, '0');
+    const second = String(sTimes[2] ?? 0).padStart(2, '0');
+    return fromZonedTime(`2000-09-${day}T${hour}:${minute}:${second}`, timezone);
   }
 
   adjustTimeWindows(profile: CEProfile) {
@@ -298,11 +301,10 @@ class CETimeWindowService {
   }
 
   toString(tw: TimeWindow, timeZone?: string): string {
-    let start_time = toZonedTime(tw.start_date_time, timeZone ?? DEFAULT_TIMEZONE)
-    let end_time = toZonedTime(tw.end_date_time, timeZone ?? DEFAULT_TIMEZONE)
-    const day = format(start_time, "EEE");
-    const start = format(start_time, "haaa");
-    const end = format(end_time, "haaa");
+    const timezone = timeZone ?? DEFAULT_TIMEZONE;
+    const day = formatInTimeZone(tw.start_date_time, timezone, "EEE");
+    const start = formatInTimeZone(tw.start_date_time, timezone, "haaa");
+    const end = formatInTimeZone(tw.end_date_time, timezone, "haaa");
 
     return `${day} ${start} - ${end}`
   }

--- a/src/services/time/ceTimeWindowService.ts
+++ b/src/services/time/ceTimeWindowService.ts
@@ -236,7 +236,7 @@ class CETimeWindowService {
 
   // Arbitrairly chose year 2000, September (month 8), and day 1 + dayOffset
   // dayOffset is 0 for Friday, 1 for Saturday, and 2 for Sunday
-  toZonedTime(dayOffset: number, time: string, timezone: string): Date {
+  localTimeToUTC(dayOffset: number, time: string, timezone: string): Date {
     const sTimes = time
       .split(':')
       .map((s) => Number.parseInt(s));
@@ -253,8 +253,8 @@ class CETimeWindowService {
         .forEach(timeWindow => {
           const dayOffset = timeWindow.day_in_week === 'Friday' ? 0
             : timeWindow.day_in_week === 'Saturday' ? 1 : 2;
-          timeWindow.start_date_time = this.toZonedTime(dayOffset, timeWindow.start_t, profile.time_zone!);
-          timeWindow.end_date_time = this.toZonedTime(dayOffset, timeWindow.end_t, profile.time_zone!);
+          timeWindow.start_date_time = this.localTimeToUTC(dayOffset, timeWindow.start_t, profile.time_zone!);
+          timeWindow.end_date_time = this.localTimeToUTC(dayOffset, timeWindow.end_t, profile.time_zone!);
         });
     }
   }
@@ -333,8 +333,8 @@ class CETimeWindowService {
       start_t: '07:00:00',
       end_t: '22:00:00',
     } as TimeWindow
-    friday.start_date_time = this.toZonedTime(0, friday.start_t, DEFAULT_TIMEZONE);
-    friday.end_date_time = this.toZonedTime(0, friday.end_t, DEFAULT_TIMEZONE);
+    friday.start_date_time = this.localTimeToUTC(0, friday.start_t, DEFAULT_TIMEZONE);
+    friday.end_date_time = this.localTimeToUTC(0, friday.end_t, DEFAULT_TIMEZONE);
 
     const saturday = {
       id: uuid(),
@@ -344,8 +344,8 @@ class CETimeWindowService {
       start_t: '07:00:00',
       end_t: '22:00:00',
     } as TimeWindow
-    saturday.start_date_time = this.toZonedTime(1, saturday.start_t, DEFAULT_TIMEZONE);
-    saturday.end_date_time = this.toZonedTime(1, saturday.end_t, DEFAULT_TIMEZONE);
+    saturday.start_date_time = this.localTimeToUTC(1, saturday.start_t, DEFAULT_TIMEZONE);
+    saturday.end_date_time = this.localTimeToUTC(1, saturday.end_t, DEFAULT_TIMEZONE);
 
     const sunday = {
       id: uuid(),
@@ -355,8 +355,8 @@ class CETimeWindowService {
       start_t: '07:00:00',
       end_t: '22:00:00',
     } as TimeWindow
-    sunday.start_date_time = this.toZonedTime(2, sunday.start_t, DEFAULT_TIMEZONE);
-    sunday.end_date_time = this.toZonedTime(2, sunday.end_t, DEFAULT_TIMEZONE);
+    sunday.start_date_time = this.localTimeToUTC(2, sunday.start_t, DEFAULT_TIMEZONE);
+    sunday.end_date_time = this.localTimeToUTC(2, sunday.end_t, DEFAULT_TIMEZONE);
 
     return [friday, saturday, sunday];
   }


### PR DESCRIPTION
## Description

Fixes timezone-dependent time window behavior and tests.

Previously, `CETimeWindowService.toZonedTime(...)` built dates using the machine’s local timezone, then converted them with `toZonedTime(...)`. This made time window calculations and tests depend on where the code was running, for example Los Angeles vs Chicago vs CI.

This change uses `fromZonedTime(...)` to create the correct instant from a timezone-local wall-clock time, and uses `formatInTimeZone(...)` when formatting or asserting time window values. Reviewers may want to pay attention to the semantic change in the Mexico City test: `07:00` in `America/Mexico_City` now remains `07:00` when viewed in that timezone.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue # CEMT-148
- Closes # CEMT-148

## QA Instructions, Screenshots, Recordings

Run the targeted timezone tests:

```bash
npm test -- --run src/services/time/ceTimeWindowService.test.ts src/services/time/ceTimeWindowService-union-merge.test.ts