### PR TITLE
CEMT-149: Fix Supabase configuration for unit tests

### DIFF
--- a/src/services/cePlacementService.test.ts
+++ b/src/services/cePlacementService.test.ts
@@ -3,19 +3,9 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 
+import { CEPlacementDao } from '../api/cePlacementDao';
 import { CEStudentDao } from '../api/ceStudentDao';
 import { CEPlacementService } from './cePlacementService';
-
-// Mock supabase client chain used in updatePlacement
-vi.mock('@digitalaidseattle/supabase', () => {
-  const single = vi.fn(() => Promise.resolve({ data: { plan_id: 'plan1', student_id: 'student1', anchor: true }, error: null }));
-  const select = vi.fn(() => ({ single }));
-  const eq2 = vi.fn(() => ({ select }));
-  const eq1 = vi.fn(() => ({ eq: eq2 }));
-  const update = vi.fn(() => ({ eq: eq1 }));
-  const from = vi.fn(() => ({ update }));
-  return { supabaseClient: { from } };
-});
 
 vi.mock('./ceStudentService', () => {
   return {
@@ -45,6 +35,9 @@ describe('cePlacementService', () => {
   const fixture = new PlacementFixture();
 
   it('propagates anchor to student when updatePlacement is called with anchor', async () => {
+    vi.spyOn(CEPlacementDao.getInstance(), 'updatePlacement')
+      .mockResolvedValue({ plan_id: 'plan1', student_id: 'student1', anchor: true } as any);
+    vi.spyOn(CEStudentDao.getInstance(), 'update').mockResolvedValue({} as any);
     const res = await fixture.runUpdate();
     // placement update should return the mocked data
     expect(res.plan_id).toBe('plan1');

--- a/src/services/group/ceGroupService-save.test.ts
+++ b/src/services/group/ceGroupService-save.test.ts
@@ -31,19 +31,21 @@ describe("groupService-save", () => {
         } as Group;
 
         const inserted = {
+            id: "test"
         } as Group;
 
         // Using a spy here to check if methods are called
         // Spies are a simpler alternative to mockFunctions. You can specify a mock function to do more that just return a value.
-        vi.spyOn(groupDao, "insert").mockResolvedValue(inserted);
+        vi.spyOn(groupDao, "upsert").mockResolvedValue(inserted);
         vi.spyOn(timeWindowDao, "deleteByGroupId").mockResolvedValue(true);
+        vi.spyOn(timeWindowDao, "insert").mockResolvedValue(savedTw);
         vi.spyOn(timeWindowService, "save").mockResolvedValue(savedTw);
 
         groupService.save(group)
             .then(result => {
                 expect(result).toBe(group);
                 expect(timeWindowDao.deleteByGroupId).toHaveBeenCalledWith("test");
-                expect(timeWindowService.save).toHaveBeenCalledWith(tw);
+                expect(timeWindowDao.insert).toHaveBeenCalledWith(tw);
             })
     });
 

--- a/src/services/plan/cePlanService.test.ts
+++ b/src/services/plan/cePlanService.test.ts
@@ -49,10 +49,10 @@ describe("planService", () => {
         const placement2 = { group_id: null } as Placement;
         const group = { id: "group1" } as Group;
 
-        (placementDao.mapJson as ReturnType<typeof vi.fn>)
+        vi.spyOn(placementDao, 'mapJson')
             .mockReturnValueOnce(placement1)
             .mockReturnValueOnce(placement2);
-        (groupDao.mapJson as ReturnType<typeof vi.fn>).mockReturnValue(group);
+        vi.spyOn(groupDao, 'mapJson').mockReturnValue(group);
 
         const result = planDao.mapJson(json);
         expectTypeOf(result).toMatchTypeOf<Plan>();

--- a/src/services/plan/planGenerator.test.ts
+++ b/src/services/plan/planGenerator.test.ts
@@ -12,32 +12,6 @@ import { CEPlanDao } from "../../api/cePlanDao";
 import { Group, Placement, Plan, TimeWindow } from "../../api/types";
 import { CEPlacementService } from "../cePlacementService";
 
-vi.mock("./cePlacementService", () => {
-    return {
-        placementService: {
-            updatePlacement: vi.fn(),
-
-        }
-    };
-});
-
-vi.mock("./ceGroupService", () => {
-    return {
-        groupService: {
-            deleteGroup: vi.fn(),
-            createDefaultTimewindows: vi.fn()
-        },
-    };
-});
-
-vi.mock("./planDao", () => {
-    return {
-        planDao: {
-            getById: vi.fn(),
-        },
-    };
-});
-
 describe("planGenerator", () => {
     const groupService = CEGroupService.getInstance();
     const planDao = CEPlanDao.getInstance();
@@ -67,9 +41,9 @@ describe("planGenerator", () => {
             id: "test-empty"
         } as Plan;
 
-        (placementService.updatePlacement as ReturnType<typeof vi.fn>).mockResolvedValue(Promise.resolve(placementLessPlan));
-        (groupService.deleteGroup as ReturnType<typeof vi.fn>).mockResolvedValue(Promise.resolve());
-        (planDao.getById as ReturnType<typeof vi.fn>).mockResolvedValue(Promise.resolve(emptyPlan));
+        vi.spyOn(placementService, 'updatePlacement').mockResolvedValue(placementLessPlan as any);
+        vi.spyOn(groupService, 'deleteGroup').mockResolvedValue(undefined as any);
+        vi.spyOn(planDao, 'getById').mockResolvedValue(emptyPlan as any);
 
         PlanGenerator.getInstance().emptyPlan(plan)
             .then(result => {
@@ -87,7 +61,7 @@ describe("planGenerator", () => {
             id: "test"
         } as Plan;
 
-        (groupService.createDefaultTimewindows as ReturnType<typeof vi.fn>).mockReturnValue([{} as TimeWindow]);
+        vi.spyOn(groupService, 'createDefaultTimewindows').mockReturnValue([{} as TimeWindow]);
         PlanGenerator.getInstance().createGroups(plan, 2)
             .then(result => {
                 expect(result.length).toBe(2);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,11 +1,25 @@
-
 import { vi } from 'vitest';
+import { setConfiguration } from './src/api/Configuration';
+
+setConfiguration({
+  supabaseClient: {} as any
+});
 
 vi.mock('@digitalaidseattle/supabase', () => ({
   createClient: vi.fn(() => ({
     auth: {
       signInWithOAuth: vi.fn(),
-      // etc.
     }
   })),
+  supabaseClient: {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      upsert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+    })),
+  },
 }));


### PR DESCRIPTION
## Summary

- Added `setConfiguration()` call in `vitest.setup.ts` so DAOs can initialize without crashing ("System needs to be configured")
- Added `supabaseClient` export to global Supabase mock so DAOs that import it directly don't error
- Replaced broken `vi.mock()` module-level mocks with `vi.spyOn()` on real singleton instances in test files
- Fixed incorrect spy targets in `ceGroupService-save.test.ts` (`insert` → `upsert`, added missing `timeWindowDao.insert` spy)

## Root Cause

All DAO classes call `getSupabaseClient()` during initialization, which requires `setConfiguration()` to be called first. Without it, every test suite that instantiated a DAO crashed before any test could run.

Additionally, several tests used `vi.mock()` to intercept module exports, but the service classes internally use `getInstance()` (singleton pattern) — not named imports — so the mocks never intercepted the actual calls.

## Test Results

Before: 5 suites crashed on load, 13 tests passing
After: All suites load, 20 tests passing (remaining 15 failures are timezone-related, tracked separately in CEMT-148)

## Related

- CEMT-148: Fix timezone-sensitive test failures (separate branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)