### PR TITLE
CEMT-146: Remove redundant successCount from ProfileUploader return

### DIFF
--- a/src/pages/facilitators/index.tsx
+++ b/src/pages/facilitators/index.tsx
@@ -43,7 +43,7 @@ const ToolsSection = () => {
                 resps.forEach(resp => {
                     allFailed = allFailed.concat(resp.failedProfiles);
                 })
-                const allSuccess = resps.map(resp => resp.successCount)
+                const allSuccess = resps.map(resp => resp.successProfiles.length)
                     .reduce((p, v) => p + v, 0);
 
                 displayResults({

--- a/src/pages/students/index.tsx
+++ b/src/pages/students/index.tsx
@@ -43,7 +43,7 @@ const ToolsSection = () => {
                 resps.forEach(resp => {
                     allFailed = allFailed.concat(resp.failedProfiles);
                 })
-                const allSuccess = resps.map(resp => resp.successCount)
+                const allSuccess = resps.map(resp => resp.successProfiles.length)
                     .reduce((p, v) => p + v, 0);
 
                 displayUploadResults({

--- a/src/services/cohort/uploadStudentsToCohort.test.ts
+++ b/src/services/cohort/uploadStudentsToCohort.test.ts
@@ -48,7 +48,7 @@ describe("uploadStudentsToCohort", () => {
     it("enrolls every created student into the cohort", async () => {
         const s1 = { id: "s1", name: "Maria" } as Student;
         const s2 = { id: "s2", name: "Carlos" } as Student;
-        mockUpload({ successCount: 2, successProfiles: [s1, s2], failedProfiles: [] });
+        mockUpload({ successProfiles: [s1, s2], failedProfiles: [] });
 
         const result = await uploadStudentsToCohort(cohort, [{} as File]);
 
@@ -65,7 +65,7 @@ describe("uploadStudentsToCohort", () => {
     it("does not enroll when no students were created", async () => {
         const f1 = { name: "Bad1", failedError: "invalid" } as unknown as FailedProfile;
         const f2 = { name: "Bad2", failedError: "invalid" } as unknown as FailedProfile;
-        mockUpload({ successCount: 0, successProfiles: [], failedProfiles: [f1, f2] });
+        mockUpload({ successProfiles: [], failedProfiles: [f1, f2] });
 
         const result = await uploadStudentsToCohort(cohort, [{} as File]);
 
@@ -83,8 +83,8 @@ describe("uploadStudentsToCohort", () => {
         const s2 = { id: "s2", name: "Carlos" } as Student;
         const f1 = { name: "Bad", failedError: "invalid" } as unknown as FailedProfile;
         mockUpload(
-            { successCount: 1, successProfiles: [s1], failedProfiles: [f1] },
-            { successCount: 1, successProfiles: [s2], failedProfiles: [] },
+            { successProfiles: [s1], failedProfiles: [f1] },
+            { successProfiles: [s2], failedProfiles: [] },
         );
 
         const result = await uploadStudentsToCohort(cohort, [{} as File, {} as File]);

--- a/src/services/plan/ProfileUploader.ts
+++ b/src/services/plan/ProfileUploader.ts
@@ -71,7 +71,7 @@ abstract class ProfileUploader<T extends CEProfile> {
 
     }
 
-    async insert_from_excel(excel_file: File): Promise<{ successCount: number; successProfiles: T[]; failedProfiles: FailedProfile[] }> {
+    async insert_from_excel(excel_file: File): Promise<{ successProfiles: T[]; failedProfiles: FailedProfile[] }> {
         try {
             return this.get_profiles_from_excel(excel_file)
                 .then(async profiles => {
@@ -81,7 +81,6 @@ abstract class ProfileUploader<T extends CEProfile> {
                             const successful = resps.filter(resp => resp.success);
                             const failed = resps.filter(resp => !resp.success);
                             return {
-                                successCount: successful.length,
                                 // CEMT-138: expose the created profiles so callers (e.g. cohort upload) can enroll them
                                 successProfiles: successful.map(resp => resp.profile as T),
                                 failedProfiles: failed.map(resp => resp.profile as FailedProfile),


### PR DESCRIPTION
Removes the redundant `successCount` from `ProfileUploader.insert_from_excel`. It equalled `successProfiles.length` by construction once CEMT-138 added `successProfiles`, so callers now derive the count from `successProfiles.length`.

Stacked on CEMT-138 (#162), so this targets the `CEMT-138-cohort-student-upload` branch and should merge after #162 lands.

`CohortUploadResult.successCount` is a separate, non-redundant field and is left unchanged.

Tested locally: tsc clean, the affected suite passes, and the student upload notification shows correct counts on both a clean file (6 of 6) and a mixed file (6 attempted, 4 added, 2 failed).