### PR TITLE
CEMT-142 Add city, age, and gender fields to plan export

### DIFF
--- a/src/services/plan/planExporter.ts
+++ b/src/services/plan/planExporter.ts
@@ -45,6 +45,7 @@ class PlanExporter {
                     [UI_STRINGS.NAME]: facilitator.name || "",
                     [UI_STRINGS.TYPE]: "Facilitator",
                     [UI_STRINGS.EMAIL]: facilitator.email || "",
+                    [UI_STRINGS.CITY]: facilitator.city,
                     [UI_STRINGS.COUNTRY]: facilitator.country,
                     [UI_STRINGS.TIME_ZONE]: facilitator.time_zone,
                     [UI_STRINGS.STUDENT_TIMES]: (facilitator.timeWindows ?? []).map(tw => timeWindowService.toString(tw)).join(', '),
@@ -63,7 +64,10 @@ class PlanExporter {
                     [UI_STRINGS.NAME]: student.name || "",
                     [UI_STRINGS.TYPE]: student.anchor ? "Anchor" : "",
                     [UI_STRINGS.EMAIL]: student.email || "",
+                    [UI_STRINGS.CITY]: student.city,
                     [UI_STRINGS.COUNTRY]: student.country,
+                    [UI_STRINGS.AGE]: student.age,
+                    [UI_STRINGS.GENDER]: student.gender,
                     [UI_STRINGS.TIME_ZONE]: student.time_zone,
                     [UI_STRINGS.STUDENT_TIMES]: (student.timeWindows ?? []).map(tw => timeWindowService.toString(tw)).join(', '),
                 };
@@ -84,7 +88,10 @@ class PlanExporter {
                 [UI_STRINGS.NAME]: student.name || "",
                 [UI_STRINGS.TYPE]: student.anchor ? "Anchor" : "",
                 [UI_STRINGS.EMAIL]: student.email || "",
+                [UI_STRINGS.CITY]: student.city,
                 [UI_STRINGS.COUNTRY]: student.country,
+                [UI_STRINGS.AGE]: student.age,
+                [UI_STRINGS.GENDER]: student.gender,
                 [UI_STRINGS.TIME_ZONE]: student.time_zone,
                 [UI_STRINGS.STUDENT_TIMES]: (student.timeWindows ?? []).map(tw => timeWindowService.toString(tw)).join(", ")
             });


### PR DESCRIPTION
## Description

Adds `City`, `Age`, and `Gender` columns to the plan export (`.xlsx`). Previously these fields were missing from the exported file even though they are stored on the student profile.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Closes #CEMT-142

## QA Instructions, Screenshots, Recordings

1. Go to a Plan page
2. Click **Export** in the toolbar
3. Open the downloaded `.xlsx` file

**Before:** 
<img width="571" height="212" alt="Screenshot 2026-07-23 at 3 38 28 AM" src="https://github.com/user-attachments/assets/4f686818-ede0-4f04-b4ef-50d7627319d3" />


**After:** 
<img width="738" height="207" alt="Screenshot 2026-07-23 at 3 40 41 AM" src="https://github.com/user-attachments/assets/fd8d6393-4b03-4f4e-9e4c-ba2f860af184" />
