### PR TITLE
CEMT-150: Fix Students table not refreshing after add/delete

### DIFF
--- a/src/pages/students/StudentsDetailsTable.tsx
+++ b/src/pages/students/StudentsDetailsTable.tsx
@@ -69,7 +69,7 @@ const StudentsDetailsTable: React.FC = () => {
         .catch((err) => console.error(err))
         .finally(() => setLoading(false));
     }
-  }, [paginationModel, sortModel, filterModel]);
+  }, [paginationModel, sortModel, filterModel, refresh]);
 
   const toggleAnchor = async (student: Student) => {
     try {


### PR DESCRIPTION
## Summary
- Students page (Home → Students) did not update the row list or total count after adding/deleting a student — required a manual page refresh.
- Root cause: the `useEffect` that fetches the student list in `StudentsDetailsTable.tsx` was missing `refresh` from its dependency array, so `setRefresh(refresh + 1)` (called after add/delete) never retriggered the fetch.
- Fix mirrors the existing pattern in `pages/facilitators/DetailsTable.tsx`, which already includes `refresh` in its dependency array.

## Test plan
- [x] Manually verified: delete a student not in any cohort → row disappears and total count updates immediately, no page refresh needed.
- [x] Manually verified: add a student → row appears and total count updates immediately, no page refresh needed.
- [x] Confirmed delete/add success toast was already showing correctly (unaffected by this bug).