### PR TITLE
CEMT-151: Fix large spreadsheet upload freeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ coverage
 supabase/.branches/*
 supabase/.temp/*
 .env
+
+# Large local-only test fixtures (CEMT-151) - too big to keep in repo history,
+# regenerate locally when needed for manual large-upload testing.
+test/diverse_students_5mb.xlsx
+test/large_students_10mb.xlsx

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { Config } from './Config';
 
 import "./App.css";
 import { setConfiguration } from './api/Configuration';
+import { UploadProgressProvider } from './components/UploadProgressContext';
 
 // ==============================|| APP - THEME, ROUTER, LOCAL  ||============================== //
 
@@ -59,7 +60,9 @@ const App: React.FC = () => {
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <UserContextProvider>
             <LayoutConfigurationProvider configuration={Config}>
-              <RouterProvider router={router} />
+              <UploadProgressProvider>
+                <RouterProvider router={router} />
+              </UploadProgressProvider>
             </LayoutConfigurationProvider>
           </UserContextProvider>
         </LocalizationProvider>

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -7,7 +7,8 @@
 
 import { useCallback, useMemo } from "react";
 import { useDropzone } from "react-dropzone";
-import { UI_STRINGS } from "../constants";
+import { Typography } from "@mui/material";
+import { MAX_UPLOAD_FILE_SIZE_BYTES, MAX_UPLOAD_FILE_SIZE_MB, UI_STRINGS } from "../constants";
 
 const baseStyle = {
     flex: 1,
@@ -40,16 +41,30 @@ const rejectStyle = {
 function FileUploader({ onChange }: { onChange: (files: File[]) => Promise<void> }) {
 
     const onDrop = useCallback((files: File[]) => {
-        onChange(files)
-    }, [])
+        // files here is only the accepted set - if everything was rejected
+        // (e.g. too large), there's nothing to upload. Don't call onChange,
+        // so the rejection message below stays visible instead of the parent
+        // immediately switching to its upload/progress state.
+        if (files.length > 0) {
+            onChange(files)
+        }
+    }, [onChange])
 
     const {
         getRootProps,
         getInputProps,
         isFocused,
         isDragAccept,
-        isDragReject
-    } = useDropzone({ onDrop, accept: { 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel': [] } });
+        isDragReject,
+        fileRejections
+    } = useDropzone({
+        onDrop,
+        maxSize: MAX_UPLOAD_FILE_SIZE_BYTES,
+        accept: {
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
+            'application/vnd.ms-excel': ['.xls']
+        }
+    });
 
     const style = useMemo(() => ({
         ...baseStyle,
@@ -68,6 +83,18 @@ function FileUploader({ onChange }: { onChange: (files: File[]) => Promise<void>
                 <input {...getInputProps()} />
                 <p>{UI_STRINGS.DRAG_STUDENT_FILE}</p>
             </div>
+            {fileRejections.length > 0 &&
+                <Typography color="error" variant="body2" mt={1}>
+                    {fileRejections
+                        .map(({ file, errors }) => {
+                            const reason = errors.some(e => e.code === 'file-too-large')
+                                ? `${UI_STRINGS.FILE_TOO_LARGE_PREFIX} ${MAX_UPLOAD_FILE_SIZE_MB}MB`
+                                : UI_STRINGS.FILE_INVALID_TYPE;
+                            return `${file.name}: ${reason}`;
+                        })
+                        .join(', ')}
+                </Typography>
+            }
         </div>
     );
 }

--- a/src/components/UploadProgressContext.tsx
+++ b/src/components/UploadProgressContext.tsx
@@ -1,0 +1,77 @@
+/**
+ *  UploadProgressContext.tsx
+ *
+ *  Tracks in-flight spreadsheet uploads at the App level (above the router),
+ *  so progress survives navigating to a different page mid-upload (CEMT-151).
+ *  The upload itself already keeps running in the background regardless -
+ *  this only fixes the UI losing visibility into it.
+ *
+ *  @copyright 2026 Digital Aid Seattle
+ *
+ */
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+export type UploadTask = {
+    id: string;
+    label: string;
+    completed: number;
+    total: number;
+};
+
+interface UploadProgressContextType {
+    uploads: UploadTask[];
+    startUpload: (id: string, label: string) => void;
+    updateUpload: (id: string, completed: number, total: number) => void;
+    finishUpload: (id: string) => void;
+}
+
+const UploadProgressContext = createContext<UploadProgressContextType>({
+    uploads: [],
+    startUpload: () => { },
+    updateUpload: () => { },
+    finishUpload: () => { },
+});
+
+export const UploadProgressProvider = (props: { children: React.ReactNode }) => {
+    const [uploads, setUploads] = useState<UploadTask[]>([]);
+
+    const startUpload = useCallback((id: string, label: string) => {
+        setUploads(prev => [...prev.filter(u => u.id !== id), { id, label, completed: 0, total: 0 }]);
+    }, []);
+
+    const updateUpload = useCallback((id: string, completed: number, total: number) => {
+        setUploads(prev => prev.map(u => u.id === id ? { ...u, completed, total } : u));
+    }, []);
+
+    const finishUpload = useCallback((id: string) => {
+        setUploads(prev => prev.filter(u => u.id !== id));
+    }, []);
+
+    // Warn before an accidental refresh/close while an upload is still
+    // running - a real reload kills the in-flight work with no way to resume
+    // or tell what got through (CEMT-151), unlike just switching pages.
+    useEffect(() => {
+        if (uploads.length === 0) {
+            return;
+        }
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, [uploads.length]);
+
+    const value = useMemo(
+        () => ({ uploads, startUpload, updateUpload, finishUpload }),
+        [uploads, startUpload, updateUpload, finishUpload]
+    );
+
+    return (
+        <UploadProgressContext.Provider value={value}>
+            {props.children}
+        </UploadProgressContext.Provider>
+    );
+};
+
+export const useUploadProgress = () => useContext(UploadProgressContext);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -140,6 +140,8 @@ export const UI_STRINGS = {
   UNEXPECTED_ERROR_GENERIC: 'Unexpected error:',
   STUDENT_ADDED: 'Student added successfully',
   STUDENT_ADD_FAILED: 'Failed to add student',
+  FILE_TOO_LARGE_PREFIX: 'File is too large. Maximum allowed size is',
+  FILE_INVALID_TYPE: 'File must be an Excel spreadsheet (.xlsx or .xls)',
 } as const;
 
 export const SERVICE_ERRORS = {
@@ -192,3 +194,11 @@ export const OFFICE_HOURS = Array.from({ length: ENDING_HOUR - STARTING_HOUR + 1
 
 // Default number of rows per page in tables
 export const DEFAULT_TABLE_PAGE_SIZE = 25;
+
+// Maximum allowed size for a spreadsheet upload (Students / Cohort upload)
+export const MAX_UPLOAD_FILE_SIZE_MB = 5;
+export const MAX_UPLOAD_FILE_SIZE_BYTES = MAX_UPLOAD_FILE_SIZE_MB * 1024 * 1024;
+
+// Number of profile rows written to the database concurrently during a
+// spreadsheet upload, to avoid firing thousands of simultaneous requests
+export const PROFILE_UPLOAD_BATCH_SIZE = 25;

--- a/src/pages/cohort/StudentTable.tsx
+++ b/src/pages/cohort/StudentTable.tsx
@@ -8,7 +8,7 @@
 import { useContext, useEffect, useState } from "react";
 
 // material-ui
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Button, LinearProgress, Stack, Typography } from "@mui/material";
 import {
   DataGrid,
   getGridNumericOperators,
@@ -37,6 +37,7 @@ import FailedUploadModal from "../../components/FailedUploadModal";
 import FileUploader from "../../components/FileUploader";
 import { ShowLocalTimeContext } from "../../components/ShowLocalTimeContext";
 import { TimeToggle } from "../../components/TimeToggle";
+import { useUploadProgress } from "../../components/UploadProgressContext";
 import { DEFAULT_TABLE_PAGE_SIZE, SERVICE_ERRORS, UI_STRINGS } from '../../constants';
 import { removeStudentsFromCohort } from "../../services/cohort/removeStudentsFromCohort";
 import { addStudentsToCohort } from "../../services/cohort/addStudentsToCohort";
@@ -51,6 +52,7 @@ export const StudentTable: React.FC = () => {
   const { cohort } = useContext(CohortContext);
   const notifications = useNotifications();
   const { refresh, setRefresh } = useContext(RefreshContext);
+  const { startUpload, updateUpload, finishUpload, uploads } = useUploadProgress();
 
   const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE });
   const [sortModel, setSortModel] = useState<GridSortModel>([{ field: "created_at", sort: "desc" }]);
@@ -64,6 +66,10 @@ export const StudentTable: React.FC = () => {
   const [showLocalTime, setShowLocalTime] = useState<boolean>(false);
 
   // cohort-level spreadsheet upload state
+  const uploadId = `cohort-upload-${cohort.id}`;
+  // Backed by context (not local state) so progress survives navigating away
+  // from this page and back while an upload is still running (CEMT-151).
+  const uploadProgress = uploads.find(u => u.id === uploadId) ?? null;
   const [showDropzone, setShowDropzone] = useState<boolean>(false);
   const [failedProfiles, setFailedProfiles] = useState<FailedProfile[]>([]);
   const [isFailedModalOpen, setIsFailedModalOpen] = useState<boolean>(false);
@@ -102,14 +108,19 @@ export const StudentTable: React.FC = () => {
 
   // Upload a student spreadsheet and enroll the created students into this cohort.
   async function handleUpload(files: File[]): Promise<void> {
+    startUpload(uploadId, `Cohort: ${cohort.name}`);
     try {
-      const result = await uploadStudentsToCohort(cohort, files);
+      const result = await uploadStudentsToCohort(cohort, files, (completed, total) => {
+        updateUpload(uploadId, completed, total);
+      });
       displayUploadResults(result);
     } catch (err) {
       console.error('Unexpected Error: ', err);
-      notifications.error(UI_STRINGS.ERROR_ADDING_STUDENTS);
+      const message = err instanceof Error ? err.message : String(err);
+      notifications.error(`${UI_STRINGS.ERROR_ADDING_STUDENTS} ${message}`);
       setShowDropzone(false);
     } finally {
+      finishUpload(uploadId);
       setRefresh(refresh + 1);
     }
   }
@@ -256,6 +267,7 @@ export const StudentTable: React.FC = () => {
               title={UI_STRINGS.UPLOAD}
               variant="contained"
               color="primary"
+              disabled={uploadProgress !== null}
               onClick={() => setShowDropzone(!showDropzone)}>
               {UI_STRINGS.UPLOAD}
             </Button>
@@ -277,8 +289,20 @@ export const StudentTable: React.FC = () => {
           </Stack>
           <TimeToggle />
         </Stack>
-        {showDropzone &&
+        {showDropzone && uploadProgress === null &&
           <FileUploader onChange={handleUpload} />
+        }
+        {uploadProgress !== null &&
+          <Box m={1}>
+            <LinearProgress
+              variant={uploadProgress.total > 0 ? 'determinate' : 'indeterminate'}
+              value={uploadProgress.total > 0 ? (uploadProgress.completed / uploadProgress.total) * 100 : undefined}
+            />
+            <Typography variant="body2" mt={0.5}>
+              {uploadProgress.total > 0 ? Math.round((uploadProgress.completed / uploadProgress.total) * 100) : 0}%
+              {' '}({uploadProgress.completed} / {uploadProgress.total || '?'} rows)
+            </Typography>
+          </Box>
         }
         {cohort &&
           <DataGrid

--- a/src/pages/students/index.tsx
+++ b/src/pages/students/index.tsx
@@ -6,7 +6,7 @@
  */
 import { useContext, useState } from 'react';
 // material-ui
-import { Button, Stack } from '@mui/material';
+import { Box, Button, LinearProgress, Stack, Typography } from '@mui/material';
 
 // project import
 
@@ -18,10 +18,13 @@ import FailedUploadModal from '../../components/FailedUploadModal';
 import FileUploader from '../../components/FileUploader';
 import ProfilesPage from '../../components/ProfilesPage';
 import { TimeToggle } from '../../components/TimeToggle';
+import { useUploadProgress } from '../../components/UploadProgressContext';
 import { UI_STRINGS } from '../../constants';
 import StudentModal from './StudentModal';
 import StudentsDetailsTable from './StudentsDetailsTable';
 import { CEStudentService } from '../../services/student/CEStudentService';
+
+const STUDENTS_UPLOAD_ID = 'students-upload';
 
 const ToolsSection = () => {
     const studentService = CEStudentService.getInstance();
@@ -29,6 +32,10 @@ const ToolsSection = () => {
 
     const notifications = useNotifications();
     const { refresh, setRefresh } = useContext(RefreshContext);
+    // Backed by context (not local state) so progress survives navigating away
+    // from this page and back while an upload is still running (CEMT-151).
+    const { startUpload, updateUpload, finishUpload, uploads } = useUploadProgress();
+    const uploadProgress = uploads.find(u => u.id === STUDENTS_UPLOAD_ID) ?? null;
     const [showDropzone, setShowDropzone] = useState<boolean>(false);
     const [failedProfiles, setFailedProfiles] = useState<FailedProfile[]>([]);
     const [isFailedModalOpen, setIsFailedModalOpen] = useState<boolean>(false);
@@ -36,8 +43,24 @@ const ToolsSection = () => {
     const [student, setStudent] = useState<Student>(studentService.empty());
 
     async function handleUpload(files: File[]): Promise<void> {
+        // Track per-file progress and report the aggregate across all files.
+        const progressByFile = new Array(files.length).fill(0);
+        const totalByFile = new Array(files.length).fill(0);
+        const reportProgress = (fileIndex: number, completed: number, total: number) => {
+            progressByFile[fileIndex] = completed;
+            totalByFile[fileIndex] = total;
+            updateUpload(
+                STUDENTS_UPLOAD_ID,
+                progressByFile.reduce((a, b) => a + b, 0),
+                totalByFile.reduce((a, b) => a + b, 0)
+            );
+        };
+        startUpload(STUDENTS_UPLOAD_ID, UI_STRINGS.STUDENTS_PAGE_TITLE);
+
         Promise
-            .all(files.map(file => uploadService.insert_from_excel(file)))
+            .all(files.map((file, fileIndex) =>
+                uploadService.insert_from_excel(file, (completed, total) => reportProgress(fileIndex, completed, total))
+            ))
             .then(resps => {
                 let allFailed: FailedProfile[] = [];
                 resps.forEach(resp => {
@@ -55,14 +78,11 @@ const ToolsSection = () => {
             })
             .catch((err) => {
                 console.error('Unexpected Error: ', err)
-                displayUploadResults({
-                    failedProfiles: [],
-                    successCount: 0,
-                    failedCount: files.length,
-                    attemptedCount: files.length
-                })
+                setShowDropzone(false);
+                notifications.error(`Error uploading spreadsheet: ${err.message}`);
             })
             .finally(() => {
+                finishUpload(STUDENTS_UPLOAD_ID);
                 setRefresh(refresh + 1);
             });
     }
@@ -106,6 +126,7 @@ const ToolsSection = () => {
                         title={UI_STRINGS.UPLOAD_STUDENT}
                         variant="contained"
                         color="primary"
+                        disabled={uploadProgress !== null}
                         onClick={() => setShowDropzone(!showDropzone)}>
                         {UI_STRINGS.UPLOAD}
                     </Button>
@@ -123,8 +144,20 @@ const ToolsSection = () => {
                 </Stack>
                 <TimeToggle />
             </Stack>
-            {showDropzone &&
+            {showDropzone && uploadProgress === null &&
                 <FileUploader onChange={handleUpload} />
+            }
+            {uploadProgress !== null &&
+                <Box m={2}>
+                    <LinearProgress
+                        variant={uploadProgress.total > 0 ? 'determinate' : 'indeterminate'}
+                        value={uploadProgress.total > 0 ? (uploadProgress.completed / uploadProgress.total) * 100 : undefined}
+                    />
+                    <Typography variant="body2" mt={0.5}>
+                        {uploadProgress.total > 0 ? Math.round((uploadProgress.completed / uploadProgress.total) * 100) : 0}%
+                        {' '}({uploadProgress.completed} / {uploadProgress.total || '?'} rows)
+                    </Typography>
+                </Box>
             }
             <FailedUploadModal
                 isModalOpen={isFailedModalOpen}

--- a/src/services/cohort/uploadStudentsToCohort.ts
+++ b/src/services/cohort/uploadStudentsToCohort.ts
@@ -28,12 +28,30 @@ export interface CohortUploadResult {
  * into the cohort here via addStudentsToCohort, which also copies each
  * student's anchor flag onto the new enrollment.
  */
-export async function uploadStudentsToCohort(cohort: Cohort, files: File[]): Promise<CohortUploadResult> {
+export async function uploadStudentsToCohort(
+    cohort: Cohort,
+    files: File[],
+    onProgress?: (completed: number, total: number) => void
+): Promise<CohortUploadResult> {
     try {
         const uploadService = StudentUploader.getInstance();
 
+        // Track per-file progress and report the aggregate across all files.
+        const progressByFile = new Array(files.length).fill(0);
+        const totalByFile = new Array(files.length).fill(0);
+        const reportProgress = (fileIndex: number, completed: number, total: number) => {
+            progressByFile[fileIndex] = completed;
+            totalByFile[fileIndex] = total;
+            onProgress?.(
+                progressByFile.reduce((a, b) => a + b, 0),
+                totalByFile.reduce((a, b) => a + b, 0)
+            );
+        };
+
         const responses = await Promise.all(
-            files.map(file => uploadService.insert_from_excel(file))
+            files.map((file, fileIndex) =>
+                uploadService.insert_from_excel(file, (completed, total) => reportProgress(fileIndex, completed, total))
+            )
         );
 
         const createdStudents: Student[] = [];

--- a/src/services/plan/ProfileUploader.test.ts
+++ b/src/services/plan/ProfileUploader.test.ts
@@ -1,0 +1,93 @@
+/**
+ *  ProfileUploader.test.ts
+ *
+ *  CEMT-151: insert_from_excel used to fire one unbounded Promise.all inserting
+ *  every parsed row concurrently, which fanned out into thousands of simultaneous
+ *  DB requests for large spreadsheets. It should instead write in bounded batches
+ *  and report progress after each batch.
+ *
+ *  @copyright 2026 Digital Aid Seattle
+ *
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { CEProfile } from "../../api/types";
+import { CEProfileService } from "../ceProfileService";
+import { ValidationService } from "../ValidationService";
+import { PROFILE_UPLOAD_BATCH_SIZE } from "../../constants";
+import { ProfileUploader } from "./ProfileUploader";
+
+// Minimal concrete subclass for testing: createProfile is a passthrough, and
+// get_profiles_from_excel is overridden to skip real xlsx parsing entirely so
+// these tests only exercise insert_from_excel's batching/progress behavior.
+class TestUploader extends ProfileUploader<CEProfile> {
+    constructor(
+        validationService: ValidationService<CEProfile>,
+        profileService: CEProfileService<CEProfile>,
+        private canned: CEProfile[]
+    ) {
+        super(validationService, profileService);
+    }
+    createProfile(dict: any): CEProfile {
+        return dict as CEProfile;
+    }
+    async get_profiles_from_excel(_file: File): Promise<CEProfile[]> {
+        return this.canned;
+    }
+}
+
+function makeProfiles(n: number): CEProfile[] {
+    return Array.from({ length: n }, (_, i) =>
+        ({ id: `p${i}`, name: `Profile ${i}`, email: `p${i}@test.com`, city: "City", country: "Country" } as CEProfile));
+}
+
+const passingValidation = { validate: vi.fn(() => []) } as unknown as ValidationService<CEProfile>;
+
+describe("ProfileUploader.insert_from_excel batching (CEMT-151)", () => {
+
+    it("never has more than PROFILE_UPLOAD_BATCH_SIZE saves in flight at once", async () => {
+        const profiles = makeProfiles(PROFILE_UPLOAD_BATCH_SIZE * 3 + 4);
+        let inFlight = 0;
+        let maxInFlight = 0;
+        const save = vi.fn(async (p: CEProfile) => {
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            await new Promise(resolve => setTimeout(resolve, 0));
+            inFlight--;
+            return p;
+        });
+        const profileService = { save } as unknown as CEProfileService<CEProfile>;
+        const uploader = new TestUploader(passingValidation, profileService, profiles);
+
+        const result = await uploader.insert_from_excel({} as File);
+
+        expect(result.successCount).toBe(profiles.length);
+        expect(maxInFlight).toBeGreaterThan(1); // still concurrent within a batch
+        expect(maxInFlight).toBeLessThanOrEqual(PROFILE_UPLOAD_BATCH_SIZE);
+    });
+
+    it("reports cumulative progress after each batch completes", async () => {
+        const profiles = makeProfiles(PROFILE_UPLOAD_BATCH_SIZE + 5);
+        const profileService = { save: vi.fn(async (p: CEProfile) => p) } as unknown as CEProfileService<CEProfile>;
+        const uploader = new TestUploader(passingValidation, profileService, profiles);
+
+        const progressCalls: [number, number][] = [];
+        await uploader.insert_from_excel({} as File, (completed, total) => progressCalls.push([completed, total]));
+
+        expect(progressCalls).toEqual([
+            [PROFILE_UPLOAD_BATCH_SIZE, profiles.length],
+            [profiles.length, profiles.length],
+        ]);
+    });
+
+    it("propagates the original parse error message instead of a generic one", async () => {
+        const save = vi.fn();
+        const profileService = { save } as unknown as CEProfileService<CEProfile>;
+        const uploader = new TestUploader(passingValidation, profileService, []);
+        vi.spyOn(uploader, "get_profiles_from_excel").mockRejectedValue(new Error("Failed to parse Excel file"));
+
+        await expect(uploader.insert_from_excel({} as File)).rejects.toThrow("Failed to parse Excel file");
+        expect(save).not.toHaveBeenCalled();
+    });
+
+});

--- a/src/services/plan/ProfileUploader.ts
+++ b/src/services/plan/ProfileUploader.ts
@@ -12,7 +12,7 @@ import { CEProfile, FailedProfile } from "../../api/types";
 import { ValidationService } from "../ValidationService";
 import { CEProfileService } from "../ceProfileService";
 import { CETimeWindowService } from "../time/ceTimeWindowService";
-import { SERVICE_ERRORS } from "../../constants";
+import { PROFILE_UPLOAD_BATCH_SIZE, SERVICE_ERRORS } from "../../constants";
 
 abstract class ProfileUploader<T extends CEProfile> {
     validationService: ValidationService<T>;
@@ -71,23 +71,34 @@ abstract class ProfileUploader<T extends CEProfile> {
 
     }
 
-    async insert_from_excel(excel_file: File): Promise<{ successCount: number; successProfiles: T[]; failedProfiles: FailedProfile[] }> {
+    async insert_from_excel(
+        excel_file: File,
+        onProgress?: (completed: number, total: number) => void
+    ): Promise<{ successCount: number; successProfiles: T[]; failedProfiles: FailedProfile[] }> {
+        // Let a parse failure propagate with its own specific message (thrown by
+        // get_profiles_from_excel) instead of being masked by the generic message below.
+        const profiles = await this.get_profiles_from_excel(excel_file);
+
         try {
-            return this.get_profiles_from_excel(excel_file)
-                .then(async profiles => {
-                    return Promise
-                        .all(profiles.map(profile => this.insertProfile(profile as T)))
-                        .then((resps) => {
-                            const successful = resps.filter(resp => resp.success);
-                            const failed = resps.filter(resp => !resp.success);
-                            return {
-                                successCount: successful.length,
-                                // CEMT-138: expose the created profiles so callers (e.g. cohort upload) can enroll them
-                                successProfiles: successful.map(resp => resp.profile as T),
-                                failedProfiles: failed.map(resp => resp.profile as FailedProfile),
-                            }
-                        })
-                })
+            // Insert in bounded batches instead of firing every row's request at once -
+            // an unbounded Promise.all over thousands of rows fans out into thousands of
+            // simultaneous DB round trips, which is what causes large uploads to hang (CEMT-151).
+            const resps: { success: boolean; profile: CEProfile | FailedProfile }[] = [];
+            for (let i = 0; i < profiles.length; i += PROFILE_UPLOAD_BATCH_SIZE) {
+                const batch = profiles.slice(i, i + PROFILE_UPLOAD_BATCH_SIZE);
+                const batchResps = await Promise.all(batch.map(profile => this.insertProfile(profile as T)));
+                resps.push(...batchResps);
+                onProgress?.(resps.length, profiles.length);
+            }
+
+            const successful = resps.filter(resp => resp.success);
+            const failed = resps.filter(resp => !resp.success);
+            return {
+                successCount: successful.length,
+                // CEMT-138: expose the created profiles so callers (e.g. cohort upload) can enroll them
+                successProfiles: successful.map(resp => resp.profile as T),
+                failedProfiles: failed.map(resp => resp.profile as FailedProfile),
+            }
         } catch (error) {
             console.error(SERVICE_ERRORS.ERROR_PROCESSING_EXCEL_FILE, error);
             throw new Error(SERVICE_ERRORS.FAILED_INSERT_STUDENTS_FROM_EXCEL_FILE);

--- a/src/services/time/ceTimeZoneService.ts
+++ b/src/services/time/ceTimeZoneService.ts
@@ -7,6 +7,12 @@
 
 import { CEStudentDao } from "../../api/ceStudentDao";
 
+// Trim, lowercase, and strip diacritics so "Kabul"/"kabul "/"Peru"/"Perú" all
+// hit the same cache entry instead of missing on cosmetic differences in
+// free-text spreadsheet data.
+function normalize(value: string): string {
+  return value.trim().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
 
 export class CETimeZoneService {
   private static _instance: CETimeZoneService;
@@ -21,6 +27,19 @@ export class CETimeZoneService {
   //  TODO: move this cache into persistence
   cache: Map<string, { timezone: string, offset: number }> = new Map();
 
+  // Lookups in flight, keyed the same as the cache - lets concurrent calls for
+  // the same city/country share one request instead of each firing its own.
+  private pending: Map<string, Promise<{ timezone: string, offset: number }>> = new Map();
+
+  // Counters for verifying how much load actually reaches the external API
+  // vs. being absorbed by the cache - handy when testing a new API key or
+  // diagnosing quota issues.
+  private stats = { cacheHits: 0, apiCalls: 0 };
+
+  getStats() {
+    return { ...this.stats };
+  }
+
   private constructor() {
     this.loadExisting()
       .then(() => this.cache)
@@ -32,7 +51,7 @@ export class CETimeZoneService {
       .getAll()
       .then(students =>
         students.forEach(student => {
-          const key = `${student.city}@${student.country}`;
+          const key = `${normalize(student.city)}@${normalize(student.country)}`;
           const value = { timezone: student.time_zone!, offset: student.tz_offset };
           this.cache.set(key, value);
         })
@@ -40,32 +59,49 @@ export class CETimeZoneService {
   }
 
   async lookupTimeZone(city: string, country: string): Promise<{ timezone: string, offset: number }> {
-    return fetch(`https://api.ipgeolocation.io/timezone?apiKey=${import.meta.env.VITE_IPGEOLOCATION_KEY}&location=${city},%20${country}`)
-      .then(resp => {
-        if (!resp.ok) {
-          throw new Error(`Failed to fetch timezone city: ${city}, country: ${country}`);
-        }
-        return resp.json()
-      })
-      .then(data => {
-        return {
-          timezone: data.timezone,
-          offset: data.timezone_offset
-        }
-      })
+    this.stats.apiCalls++;
+    const resp = await fetch(`https://api.ipgeolocation.io/timezone?apiKey=${import.meta.env.VITE_IPGEOLOCATION_KEY}&location=${city},%20${country}`);
+
+    if (!resp.ok) {
+      // ipgeolocation.io has no per-second/per-minute rate limit (confirmed in
+      // their docs) - a 429 here means the daily request quota is exhausted,
+      // which won't clear up on retry, only after the quota resets.
+      const reason = resp.status === 429 ? 'daily API quota likely exhausted' : `HTTP ${resp.status}`;
+      throw new Error(`Failed to fetch timezone city: ${city}, country: ${country} (${reason})`);
+    }
+    const data = await resp.json();
+    return {
+      timezone: data.timezone,
+      offset: data.timezone_offset
+    }
   }
 
   async getTimeZone(city: string, country: string): Promise<{ timezone: string, offset: number }> {
-    const key = `${city}@${country}`;
-    const value = this.cache.get(key);
-
-    if (value) {
-      return value;
+    const key = `${normalize(city)}@${normalize(country)}`;
+    const cached = this.cache.get(key);
+    if (cached) {
+      this.stats.cacheHits++;
+      return cached;
     }
-    return value ?? this.lookupTimeZone(city, country)
-      .then(lookup => {
-        this.cache.set(key, lookup);
-        return lookup;
+
+    const inFlight = this.pending.get(key);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    // No per-second rate limit on this API (confirmed in their docs), so
+    // lookups can fire directly - concurrency is naturally bounded by
+    // PROFILE_UPLOAD_BATCH_SIZE upstream in ProfileUploader.
+    const lookup = this.lookupTimeZone(city, country)
+      .then(result => {
+        this.cache.set(key, result);
+        return result;
       })
+      .finally(() => {
+        this.pending.delete(key);
+      });
+
+    this.pending.set(key, lookup);
+    return lookup;
   }
 }


### PR DESCRIPTION
## Description

Fixes the browser freeze/hang on large student spreadsheet uploads.

**Root cause**: `ProfileUploader.insert_from_excel` fired one unbounded `Promise.all` covering every parsed row, so a spreadsheet with thousands of students fanned out into thousands of simultaneous DB inserts (and, for rows needing geocoding, thousands of simultaneous calls to the external `ipgeolocation.io` timezone API). This is what hung the tab on large files.

**What this PR changes**:
- Client-side cap of 5MB / `.xlsx`/`.xls` only on `FileUploader`, with a clear rejection message instead of silently accepting oversized files.
- `insert_from_excel` now writes in bounded batches (`PROFILE_UPLOAD_BATCH_SIZE = 25`) instead of one giant `Promise.all`, and reports progress after each batch.
- `CETimeZoneService` dedupes concurrent lookups for the same city/country (in-flight requests are shared instead of each firing its own call), normalizes cache keys (trim/lowercase/strip diacritics) so near-duplicate spreadsheet text still hits cache, and surfaces a clearer error when the API responds 429 (daily quota likely exhausted, per their docs there's no per-second limit).
- New `UploadProgressContext`, mounted above the router in `App.tsx`, tracks in-flight uploads so the progress bar survives navigating to another page and back, and warns before an accidental tab close/refresh while an upload is running.
- Upload buttons are disabled while an upload for that page is in progress, to prevent a second overlapping upload.

**Known limitation this PR does *not* solve**: the import still has no fallback path if the external timezone API is unavailable or its quota is exhausted mid-import — the whole batch fails with no way to resume, edit, or retry just the affected rows. That's a bigger, separate change (see proposal below); this PR only stops the freeze itself.

## Known Limitation & Proposed Future Workflow

The current upload flow writes directly to `students`/`enrollment` while parsing, calling the external timezone API inline per row. If that API is down or the daily quota runs out partway through a large file, there is no fallback — the import simply fails, and it's unclear which rows made it in.

Proposing a preview-then-commit workflow for a follow-up ticket, so a bad row (or an API outage) blocks only itself, not the whole import, and nothing is written until the user explicitly confirms:

```
① Select file
   ↓
② Front-end pre-check (extension / size)
   ↓
③ Upload raw file to Supabase Storage
   ↓
④ Edge Function parses it → returns a structured preview (no writes to real tables yet)
   ↓
⑤ Preview screen:
   - Blocking Error → highlighted red, must be fixed before continuing
   - Warning → highlighted yellow, inline-editable or can be dismissed
   - Info (e.g. duplicate student) → prompts the user to choose how to resolve it
   ↓
⑥ User clicks "Confirm Import" → only then does it write to students / availability
   ↓
⑦ Import result report (success / skipped / failed counts)
```

This would let a timezone-lookup failure (or any other per-row problem) show up as a blocking error on that row in the preview, rather than aborting the entire import — and gives the user a chance to fix or skip it before anything is committed. Opening a follow-up ticket for this; not in scope for this PR.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue # CEMT-151
- Closes # CEMT-151

## QA Instructions, Screenshots, Recordings

- `npx tsc --noEmit` and `npx vitest run src/services/plan/ProfileUploader.test.ts` both pass (new tests cover batching bound and progress reporting).
- Manual: upload a large spreadsheet (1000+ rows) to Students or a Cohort and confirm the tab stays responsive, the progress bar advances in batches of 25, and it keeps showing progress if you navigate to another page and back.
- Manual: try uploading a file >5MB or a non-Excel file and confirm the inline rejection message appears instead of the upload silently starting.
- Manual: try closing/refreshing the tab mid-upload and confirm the browser's native "leave site?" warning appears.
