### PR TITLE
CEMT-151: Batch spreadsheet upload DB writes

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -192,3 +192,7 @@ export const OFFICE_HOURS = Array.from({ length: ENDING_HOUR - STARTING_HOUR + 1
 
 // Default number of rows per page in tables
 export const DEFAULT_TABLE_PAGE_SIZE = 25;
+
+// Number of profile rows written to the database concurrently during a
+// spreadsheet upload, to avoid firing thousands of simultaneous requests
+export const PROFILE_UPLOAD_BATCH_SIZE = 25;

--- a/src/services/plan/ProfileUploader.test.ts
+++ b/src/services/plan/ProfileUploader.test.ts
@@ -1,0 +1,78 @@
+/**
+ *  ProfileUploader.test.ts
+ *
+ *  CEMT-151: insert_from_excel used to fire one unbounded Promise.all inserting
+ *  every parsed row concurrently, which fanned out into thousands of simultaneous
+ *  DB requests for large spreadsheets. It should instead write in bounded batches.
+ *
+ *  @copyright 2026 Digital Aid Seattle
+ *
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { CEProfile } from "../../api/types";
+import { CEProfileService } from "../ceProfileService";
+import { ValidationService } from "../ValidationService";
+import { PROFILE_UPLOAD_BATCH_SIZE } from "../../constants";
+import { ProfileUploader } from "./ProfileUploader";
+
+// Minimal concrete subclass for testing: createProfile is a passthrough, and
+// get_profiles_from_excel is overridden to skip real xlsx parsing entirely so
+// these tests only exercise insert_from_excel's batching behavior.
+class TestUploader extends ProfileUploader<CEProfile> {
+    constructor(
+        validationService: ValidationService<CEProfile>,
+        profileService: CEProfileService<CEProfile>,
+        private canned: CEProfile[]
+    ) {
+        super(validationService, profileService);
+    }
+    createProfile(dict: any): CEProfile {
+        return dict as CEProfile;
+    }
+    async get_profiles_from_excel(_file: File): Promise<CEProfile[]> {
+        return this.canned;
+    }
+}
+
+function makeProfiles(n: number): CEProfile[] {
+    return Array.from({ length: n }, (_, i) =>
+        ({ id: `p${i}`, name: `Profile ${i}`, email: `p${i}@test.com`, city: "City", country: "Country" } as CEProfile));
+}
+
+const passingValidation = { validate: vi.fn(() => []) } as unknown as ValidationService<CEProfile>;
+
+describe("ProfileUploader.insert_from_excel batching (CEMT-151)", () => {
+
+    it("never has more than PROFILE_UPLOAD_BATCH_SIZE saves in flight at once", async () => {
+        const profiles = makeProfiles(PROFILE_UPLOAD_BATCH_SIZE * 3 + 4);
+        let inFlight = 0;
+        let maxInFlight = 0;
+        const save = vi.fn(async (p: CEProfile) => {
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            await new Promise(resolve => setTimeout(resolve, 0));
+            inFlight--;
+            return p;
+        });
+        const profileService = { save } as unknown as CEProfileService<CEProfile>;
+        const uploader = new TestUploader(passingValidation, profileService, profiles);
+
+        const result = await uploader.insert_from_excel({} as File);
+
+        expect(result.successCount).toBe(profiles.length);
+        expect(maxInFlight).toBeGreaterThan(1); // still concurrent within a batch
+        expect(maxInFlight).toBeLessThanOrEqual(PROFILE_UPLOAD_BATCH_SIZE);
+    });
+
+    it("propagates the original parse error message instead of a generic one", async () => {
+        const save = vi.fn();
+        const profileService = { save } as unknown as CEProfileService<CEProfile>;
+        const uploader = new TestUploader(passingValidation, profileService, []);
+        vi.spyOn(uploader, "get_profiles_from_excel").mockRejectedValue(new Error("Failed to parse Excel file"));
+
+        await expect(uploader.insert_from_excel({} as File)).rejects.toThrow("Failed to parse Excel file");
+        expect(save).not.toHaveBeenCalled();
+    });
+
+});

--- a/src/services/plan/ProfileUploader.ts
+++ b/src/services/plan/ProfileUploader.ts
@@ -12,7 +12,7 @@ import { CEProfile, FailedProfile } from "../../api/types";
 import { ValidationService } from "../ValidationService";
 import { CEProfileService } from "../ceProfileService";
 import { CETimeWindowService } from "../time/ceTimeWindowService";
-import { SERVICE_ERRORS } from "../../constants";
+import { PROFILE_UPLOAD_BATCH_SIZE, SERVICE_ERRORS } from "../../constants";
 
 abstract class ProfileUploader<T extends CEProfile> {
     validationService: ValidationService<T>;
@@ -72,22 +72,29 @@ abstract class ProfileUploader<T extends CEProfile> {
     }
 
     async insert_from_excel(excel_file: File): Promise<{ successCount: number; successProfiles: T[]; failedProfiles: FailedProfile[] }> {
+        // Let a parse failure propagate with its own specific message (thrown by
+        // get_profiles_from_excel) instead of being masked by the generic message below.
+        const profiles = await this.get_profiles_from_excel(excel_file);
+
         try {
-            return this.get_profiles_from_excel(excel_file)
-                .then(async profiles => {
-                    return Promise
-                        .all(profiles.map(profile => this.insertProfile(profile as T)))
-                        .then((resps) => {
-                            const successful = resps.filter(resp => resp.success);
-                            const failed = resps.filter(resp => !resp.success);
-                            return {
-                                successCount: successful.length,
-                                // CEMT-138: expose the created profiles so callers (e.g. cohort upload) can enroll them
-                                successProfiles: successful.map(resp => resp.profile as T),
-                                failedProfiles: failed.map(resp => resp.profile as FailedProfile),
-                            }
-                        })
-                })
+            // Insert in bounded batches instead of firing every row's request at once -
+            // an unbounded Promise.all over thousands of rows fans out into thousands of
+            // simultaneous DB round trips, which is what causes large uploads to hang (CEMT-151).
+            const resps: { success: boolean; profile: CEProfile | FailedProfile }[] = [];
+            for (let i = 0; i < profiles.length; i += PROFILE_UPLOAD_BATCH_SIZE) {
+                const batch = profiles.slice(i, i + PROFILE_UPLOAD_BATCH_SIZE);
+                const batchResps = await Promise.all(batch.map(profile => this.insertProfile(profile as T)));
+                resps.push(...batchResps);
+            }
+
+            const successful = resps.filter(resp => resp.success);
+            const failed = resps.filter(resp => !resp.success);
+            return {
+                successCount: successful.length,
+                // CEMT-138: expose the created profiles so callers (e.g. cohort upload) can enroll them
+                successProfiles: successful.map(resp => resp.profile as T),
+                failedProfiles: failed.map(resp => resp.profile as FailedProfile),
+            }
         } catch (error) {
             console.error(SERVICE_ERRORS.ERROR_PROCESSING_EXCEL_FILE, error);
             throw new Error(SERVICE_ERRORS.FAILED_INSERT_STUDENTS_FROM_EXCEL_FILE);


### PR DESCRIPTION
## Description

Split out from the original CEMT-151 PR per team lead's request. This is the core fix for the freeze itself and has no dependency on the timezone caching or upload-progress-UI pieces (also being split out separately) - safe to merge on its own and should be prioritized, since it's the actual bug fix.

**Root cause**: `ProfileUploader.insert_from_excel` fired one unbounded `Promise.all` covering every parsed row. A spreadsheet with thousands of students fanned out into thousands of simultaneous DB inserts (and, for rows needing geocoding, thousands of simultaneous external API calls), which is what hung the tab.

**Fix**: writes now happen in bounded batches of `PROFILE_UPLOAD_BATCH_SIZE` (25), awaited sequentially batch-by-batch instead of all at once.

Also small related fix: a spreadsheet parse failure (bad file format, etc.) now propagates with its own specific error message instead of being masked by a generic "failed to insert" message - it was already being caught and rethrown with a generic message one layer up regardless, so this just surfaces the real reason.

Note: there's no progress indicator wired up in this PR (no UI change) - that's the follow-up "upload progress" PR, which builds on top of this batching.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue # CEMT-151

## QA Instructions, Screenshots, Recordings

- `npx tsc --noEmit` clean; `npx vitest run src/services/plan/ProfileUploader.test.ts` passes (new tests assert batching never exceeds `PROFILE_UPLOAD_BATCH_SIZE` concurrent saves, and that parse errors propagate with their real message).
- Manual: upload a large spreadsheet (1000+ rows) to Students or a Cohort and confirm the tab stays responsive throughout (no progress bar yet - that's the next PR).