### PR TITLE
CEMT-151: Upload progress indicator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { Config } from './Config';
 
 import "./App.css";
 import { setConfiguration } from './api/Configuration';
+import { UploadProgressProvider } from './components/UploadProgressContext';
 
 // ==============================|| APP - THEME, ROUTER, LOCAL  ||============================== //
 
@@ -59,7 +60,9 @@ const App: React.FC = () => {
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <UserContextProvider>
             <LayoutConfigurationProvider configuration={Config}>
-              <RouterProvider router={router} />
+              <UploadProgressProvider>
+                <RouterProvider router={router} />
+              </UploadProgressProvider>
             </LayoutConfigurationProvider>
           </UserContextProvider>
         </LocalizationProvider>

--- a/src/components/UploadProgressContext.tsx
+++ b/src/components/UploadProgressContext.tsx
@@ -1,0 +1,78 @@
+/**
+ *  UploadProgressContext.tsx
+ *
+ *  Tracks in-flight spreadsheet uploads at the App level (above the router),
+ *  so progress survives navigating to a different page mid-upload (CEMT-151).
+ *  The upload itself already keeps running in the background regardless -
+ *  this only fixes the UI losing visibility into it.
+ *
+ *  @copyright 2026 Digital Aid Seattle
+ *
+ */
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+export type UploadTask = {
+    id: string;
+    label: string;
+    completed: number;
+    total: number;
+};
+
+interface UploadProgressContextType {
+    uploads: UploadTask[];
+    startUpload: (id: string, label: string) => void;
+    updateUpload: (id: string, completed: number, total: number) => void;
+    finishUpload: (id: string) => void;
+}
+
+const UploadProgressContext = createContext<UploadProgressContextType>({
+    uploads: [],
+    startUpload: () => { },
+    updateUpload: () => { },
+    finishUpload: () => { },
+});
+
+export const UploadProgressProvider = (props: { children: React.ReactNode }) => {
+    const [uploads, setUploads] = useState<UploadTask[]>([]);
+
+    const startUpload = useCallback((id: string, label: string) => {
+        setUploads(prev => [...prev.filter(u => u.id !== id), { id, label, completed: 0, total: 0 }]);
+    }, []);
+
+    const updateUpload = useCallback((id: string, completed: number, total: number) => {
+        setUploads(prev => prev.map(u => u.id === id ? { ...u, completed, total } : u));
+    }, []);
+
+    const finishUpload = useCallback((id: string) => {
+        setUploads(prev => prev.filter(u => u.id !== id));
+    }, []);
+
+    // Warn before an accidental refresh/close while an upload is still
+    // running - a real reload kills the in-flight work with no way to resume
+    // or tell what got through (CEMT-151), unlike just switching pages.
+    useEffect(() => {
+        if (uploads.length === 0) {
+            return;
+        }
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, [uploads.length]);
+
+    const value = useMemo(
+        () => ({ uploads, startUpload, updateUpload, finishUpload }),
+        [uploads, startUpload, updateUpload, finishUpload]
+    );
+
+    return (
+        <UploadProgressContext.Provider value={value}>
+            {props.children}
+        </UploadProgressContext.Provider>
+    );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components -- Provider + hook is the standard pairing for a context module
+export const useUploadProgress = () => useContext(UploadProgressContext);

--- a/src/pages/cohort/StudentTable.tsx
+++ b/src/pages/cohort/StudentTable.tsx
@@ -8,7 +8,7 @@
 import { useContext, useEffect, useState } from "react";
 
 // material-ui
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Button, LinearProgress, Stack, Typography } from "@mui/material";
 import {
   DataGrid,
   getGridNumericOperators,
@@ -37,6 +37,7 @@ import FailedUploadModal from "../../components/FailedUploadModal";
 import FileUploader from "../../components/FileUploader";
 import { ShowLocalTimeContext } from "../../components/ShowLocalTimeContext";
 import { TimeToggle } from "../../components/TimeToggle";
+import { useUploadProgress } from "../../components/UploadProgressContext";
 import { DEFAULT_TABLE_PAGE_SIZE, SERVICE_ERRORS, UI_STRINGS } from '../../constants';
 import { removeStudentsFromCohort } from "../../services/cohort/removeStudentsFromCohort";
 import { addStudentsToCohort } from "../../services/cohort/addStudentsToCohort";
@@ -51,6 +52,7 @@ export const StudentTable: React.FC = () => {
   const { cohort } = useContext(CohortContext);
   const notifications = useNotifications();
   const { refresh, setRefresh } = useContext(RefreshContext);
+  const { startUpload, updateUpload, finishUpload, uploads } = useUploadProgress();
 
   const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE });
   const [sortModel, setSortModel] = useState<GridSortModel>([{ field: "created_at", sort: "desc" }]);
@@ -64,6 +66,10 @@ export const StudentTable: React.FC = () => {
   const [showLocalTime, setShowLocalTime] = useState<boolean>(false);
 
   // cohort-level spreadsheet upload state
+  const uploadId = `cohort-upload-${cohort.id}`;
+  // Backed by context (not local state) so progress survives navigating away
+  // from this page and back while an upload is still running (CEMT-151).
+  const uploadProgress = uploads.find(u => u.id === uploadId) ?? null;
   const [showDropzone, setShowDropzone] = useState<boolean>(false);
   const [failedProfiles, setFailedProfiles] = useState<FailedProfile[]>([]);
   const [isFailedModalOpen, setIsFailedModalOpen] = useState<boolean>(false);
@@ -102,14 +108,19 @@ export const StudentTable: React.FC = () => {
 
   // Upload a student spreadsheet and enroll the created students into this cohort.
   async function handleUpload(files: File[]): Promise<void> {
+    startUpload(uploadId, `Cohort: ${cohort.name}`);
     try {
-      const result = await uploadStudentsToCohort(cohort, files);
+      const result = await uploadStudentsToCohort(cohort, files, (completed, total) => {
+        updateUpload(uploadId, completed, total);
+      });
       displayUploadResults(result);
     } catch (err) {
       console.error('Unexpected Error: ', err);
-      notifications.error(UI_STRINGS.ERROR_ADDING_STUDENTS);
+      const message = err instanceof Error ? err.message : String(err);
+      notifications.error(`${UI_STRINGS.ERROR_ADDING_STUDENTS} ${message}`);
       setShowDropzone(false);
     } finally {
+      finishUpload(uploadId);
       setRefresh(refresh + 1);
     }
   }
@@ -256,6 +267,7 @@ export const StudentTable: React.FC = () => {
               title={UI_STRINGS.UPLOAD}
               variant="contained"
               color="primary"
+              disabled={uploadProgress !== null}
               onClick={() => setShowDropzone(!showDropzone)}>
               {UI_STRINGS.UPLOAD}
             </Button>
@@ -277,8 +289,20 @@ export const StudentTable: React.FC = () => {
           </Stack>
           <TimeToggle />
         </Stack>
-        {showDropzone &&
+        {showDropzone && uploadProgress === null &&
           <FileUploader onChange={handleUpload} />
+        }
+        {uploadProgress !== null &&
+          <Box m={1}>
+            <LinearProgress
+              variant={uploadProgress.total > 0 ? 'determinate' : 'indeterminate'}
+              value={uploadProgress.total > 0 ? (uploadProgress.completed / uploadProgress.total) * 100 : undefined}
+            />
+            <Typography variant="body2" mt={0.5}>
+              {uploadProgress.total > 0 ? Math.round((uploadProgress.completed / uploadProgress.total) * 100) : 0}%
+              {' '}({uploadProgress.completed} / {uploadProgress.total || '?'} rows)
+            </Typography>
+          </Box>
         }
         {cohort &&
           <DataGrid

--- a/src/pages/students/index.tsx
+++ b/src/pages/students/index.tsx
@@ -6,7 +6,7 @@
  */
 import { useContext, useState } from 'react';
 // material-ui
-import { Button, Stack } from '@mui/material';
+import { Box, Button, LinearProgress, Stack, Typography } from '@mui/material';
 
 // project import
 
@@ -18,10 +18,13 @@ import FailedUploadModal from '../../components/FailedUploadModal';
 import FileUploader from '../../components/FileUploader';
 import ProfilesPage from '../../components/ProfilesPage';
 import { TimeToggle } from '../../components/TimeToggle';
+import { useUploadProgress } from '../../components/UploadProgressContext';
 import { UI_STRINGS } from '../../constants';
 import StudentModal from './StudentModal';
 import StudentsDetailsTable from './StudentsDetailsTable';
 import { CEStudentService } from '../../services/student/CEStudentService';
+
+const STUDENTS_UPLOAD_ID = 'students-upload';
 
 const ToolsSection = () => {
     const studentService = CEStudentService.getInstance();
@@ -29,6 +32,10 @@ const ToolsSection = () => {
 
     const notifications = useNotifications();
     const { refresh, setRefresh } = useContext(RefreshContext);
+    // Backed by context (not local state) so progress survives navigating away
+    // from this page and back while an upload is still running (CEMT-151).
+    const { startUpload, updateUpload, finishUpload, uploads } = useUploadProgress();
+    const uploadProgress = uploads.find(u => u.id === STUDENTS_UPLOAD_ID) ?? null;
     const [showDropzone, setShowDropzone] = useState<boolean>(false);
     const [failedProfiles, setFailedProfiles] = useState<FailedProfile[]>([]);
     const [isFailedModalOpen, setIsFailedModalOpen] = useState<boolean>(false);
@@ -36,8 +43,24 @@ const ToolsSection = () => {
     const [student, setStudent] = useState<Student>(studentService.empty());
 
     async function handleUpload(files: File[]): Promise<void> {
+        // Track per-file progress and report the aggregate across all files.
+        const progressByFile = new Array(files.length).fill(0);
+        const totalByFile = new Array(files.length).fill(0);
+        const reportProgress = (fileIndex: number, completed: number, total: number) => {
+            progressByFile[fileIndex] = completed;
+            totalByFile[fileIndex] = total;
+            updateUpload(
+                STUDENTS_UPLOAD_ID,
+                progressByFile.reduce((a, b) => a + b, 0),
+                totalByFile.reduce((a, b) => a + b, 0)
+            );
+        };
+        startUpload(STUDENTS_UPLOAD_ID, UI_STRINGS.STUDENTS_PAGE_TITLE);
+
         Promise
-            .all(files.map(file => uploadService.insert_from_excel(file)))
+            .all(files.map((file, fileIndex) =>
+                uploadService.insert_from_excel(file, (completed, total) => reportProgress(fileIndex, completed, total))
+            ))
             .then(resps => {
                 let allFailed: FailedProfile[] = [];
                 resps.forEach(resp => {
@@ -55,14 +78,11 @@ const ToolsSection = () => {
             })
             .catch((err) => {
                 console.error('Unexpected Error: ', err)
-                displayUploadResults({
-                    failedProfiles: [],
-                    successCount: 0,
-                    failedCount: files.length,
-                    attemptedCount: files.length
-                })
+                setShowDropzone(false);
+                notifications.error(`Error uploading spreadsheet: ${err.message}`);
             })
             .finally(() => {
+                finishUpload(STUDENTS_UPLOAD_ID);
                 setRefresh(refresh + 1);
             });
     }
@@ -106,6 +126,7 @@ const ToolsSection = () => {
                         title={UI_STRINGS.UPLOAD_STUDENT}
                         variant="contained"
                         color="primary"
+                        disabled={uploadProgress !== null}
                         onClick={() => setShowDropzone(!showDropzone)}>
                         {UI_STRINGS.UPLOAD}
                     </Button>
@@ -123,8 +144,20 @@ const ToolsSection = () => {
                 </Stack>
                 <TimeToggle />
             </Stack>
-            {showDropzone &&
+            {showDropzone && uploadProgress === null &&
                 <FileUploader onChange={handleUpload} />
+            }
+            {uploadProgress !== null &&
+                <Box m={2}>
+                    <LinearProgress
+                        variant={uploadProgress.total > 0 ? 'determinate' : 'indeterminate'}
+                        value={uploadProgress.total > 0 ? (uploadProgress.completed / uploadProgress.total) * 100 : undefined}
+                    />
+                    <Typography variant="body2" mt={0.5}>
+                        {uploadProgress.total > 0 ? Math.round((uploadProgress.completed / uploadProgress.total) * 100) : 0}%
+                        {' '}({uploadProgress.completed} / {uploadProgress.total || '?'} rows)
+                    </Typography>
+                </Box>
             }
             <FailedUploadModal
                 isModalOpen={isFailedModalOpen}

--- a/src/services/cohort/uploadStudentsToCohort.ts
+++ b/src/services/cohort/uploadStudentsToCohort.ts
@@ -28,12 +28,30 @@ export interface CohortUploadResult {
  * into the cohort here via addStudentsToCohort, which also copies each
  * student's anchor flag onto the new enrollment.
  */
-export async function uploadStudentsToCohort(cohort: Cohort, files: File[]): Promise<CohortUploadResult> {
+export async function uploadStudentsToCohort(
+    cohort: Cohort,
+    files: File[],
+    onProgress?: (completed: number, total: number) => void
+): Promise<CohortUploadResult> {
     try {
         const uploadService = StudentUploader.getInstance();
 
+        // Track per-file progress and report the aggregate across all files.
+        const progressByFile = new Array(files.length).fill(0);
+        const totalByFile = new Array(files.length).fill(0);
+        const reportProgress = (fileIndex: number, completed: number, total: number) => {
+            progressByFile[fileIndex] = completed;
+            totalByFile[fileIndex] = total;
+            onProgress?.(
+                progressByFile.reduce((a, b) => a + b, 0),
+                totalByFile.reduce((a, b) => a + b, 0)
+            );
+        };
+
         const responses = await Promise.all(
-            files.map(file => uploadService.insert_from_excel(file))
+            files.map((file, fileIndex) =>
+                uploadService.insert_from_excel(file, (completed, total) => reportProgress(fileIndex, completed, total))
+            )
         );
 
         const createdStudents: Student[] = [];

--- a/src/services/plan/ProfileUploader.test.ts
+++ b/src/services/plan/ProfileUploader.test.ts
@@ -3,7 +3,8 @@
  *
  *  CEMT-151: insert_from_excel used to fire one unbounded Promise.all inserting
  *  every parsed row concurrently, which fanned out into thousands of simultaneous
- *  DB requests for large spreadsheets. It should instead write in bounded batches.
+ *  DB requests for large spreadsheets. It should instead write in bounded batches
+ *  and report progress after each batch.
  *
  *  @copyright 2026 Digital Aid Seattle
  *
@@ -63,6 +64,20 @@ describe("ProfileUploader.insert_from_excel batching (CEMT-151)", () => {
         expect(result.successCount).toBe(profiles.length);
         expect(maxInFlight).toBeGreaterThan(1); // still concurrent within a batch
         expect(maxInFlight).toBeLessThanOrEqual(PROFILE_UPLOAD_BATCH_SIZE);
+    });
+
+    it("reports cumulative progress after each batch completes", async () => {
+        const profiles = makeProfiles(PROFILE_UPLOAD_BATCH_SIZE + 5);
+        const profileService = { save: vi.fn(async (p: CEProfile) => p) } as unknown as CEProfileService<CEProfile>;
+        const uploader = new TestUploader(passingValidation, profileService, profiles);
+
+        const progressCalls: [number, number][] = [];
+        await uploader.insert_from_excel({} as File, (completed, total) => progressCalls.push([completed, total]));
+
+        expect(progressCalls).toEqual([
+            [PROFILE_UPLOAD_BATCH_SIZE, profiles.length],
+            [profiles.length, profiles.length],
+        ]);
     });
 
     it("propagates the original parse error message instead of a generic one", async () => {

--- a/src/services/plan/ProfileUploader.ts
+++ b/src/services/plan/ProfileUploader.ts
@@ -71,7 +71,10 @@ abstract class ProfileUploader<T extends CEProfile> {
 
     }
 
-    async insert_from_excel(excel_file: File): Promise<{ successCount: number; successProfiles: T[]; failedProfiles: FailedProfile[] }> {
+    async insert_from_excel(
+        excel_file: File,
+        onProgress?: (completed: number, total: number) => void
+    ): Promise<{ successCount: number; successProfiles: T[]; failedProfiles: FailedProfile[] }> {
         // Let a parse failure propagate with its own specific message (thrown by
         // get_profiles_from_excel) instead of being masked by the generic message below.
         const profiles = await this.get_profiles_from_excel(excel_file);
@@ -85,6 +88,7 @@ abstract class ProfileUploader<T extends CEProfile> {
                 const batch = profiles.slice(i, i + PROFILE_UPLOAD_BATCH_SIZE);
                 const batchResps = await Promise.all(batch.map(profile => this.insertProfile(profile as T)));
                 resps.push(...batchResps);
+                onProgress?.(resps.length, profiles.length);
             }
 
             const successful = resps.filter(resp => resp.success);


### PR DESCRIPTION
## Description

Split out from the original CEMT-151 PR per team lead's request - this piece needs UX review, so it's kept separate from the other CEMT-151 pieces (timezone caching, batched DB writes) which don't need it and can merge independently.

**Depends on #176** (batched DB writes) - this PR's base branch is `CEMT-151-batch-db-writes`, not `dev`, so the diff shown here is only the incremental progress work. Once #176 merges to `dev`, I'll retarget this PR's base to `dev` and the diff will shrink to just this commit.

**What's added**:
- A progress bar on the Students and Cohort upload pages, driven by `onProgress` callbacks threaded through `insert_from_excel` → `uploadStudentsToCohort` (using the batching from #176 - each batch completing advances the bar).
- A new `UploadProgressContext`, mounted above the router in `App.tsx`, so progress survives navigating to a different page and back while an upload is still running (previously this was local component state and got lost on navigation).
- A `beforeunload` warning while an upload is in progress, since a real tab close/reload kills the in-flight work with no way to resume or tell what got through.
- The upload button is disabled while an upload for that page is already running, to prevent a second overlapping upload.
- Cohort/Students upload error messages now surface the actual thrown error text instead of a generic message.

**Please give this one a UX pass** - specifically the progress bar placement/styling, the button-disabled-during-upload behavior, and the native `beforeunload` confirmation dialog (browser-styled, not customizable).

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue # CEMT-151

## QA Instructions, Screenshots, Recordings

- `npx tsc --noEmit` clean; `npx vitest run src/services/plan/ProfileUploader.test.ts` passes (includes a new test asserting progress is reported after each batch).
- Manual: upload a large spreadsheet (1000+ rows) to Students or a Cohort, confirm the progress bar advances in steps of 25, navigate to another page and back mid-upload and confirm the bar is still there, then try closing/refreshing the tab mid-upload and confirm the browser's native "leave site?" warning appears.