### PR TITLE
CEMT-151: Reject oversized/invalid files client-side (needs requirements confirmation)

### DIFF
--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -7,7 +7,8 @@
 
 import { useCallback, useMemo } from "react";
 import { useDropzone } from "react-dropzone";
-import { UI_STRINGS } from "../constants";
+import { Typography } from "@mui/material";
+import { MAX_UPLOAD_FILE_SIZE_BYTES, MAX_UPLOAD_FILE_SIZE_MB, UI_STRINGS } from "../constants";
 
 const baseStyle = {
     flex: 1,
@@ -40,16 +41,30 @@ const rejectStyle = {
 function FileUploader({ onChange }: { onChange: (files: File[]) => Promise<void> }) {
 
     const onDrop = useCallback((files: File[]) => {
-        onChange(files)
-    }, [])
+        // files here is only the accepted set - if everything was rejected
+        // (e.g. too large), there's nothing to upload. Don't call onChange,
+        // so the rejection message below stays visible instead of the parent
+        // immediately switching to its upload/progress state.
+        if (files.length > 0) {
+            onChange(files)
+        }
+    }, [onChange])
 
     const {
         getRootProps,
         getInputProps,
         isFocused,
         isDragAccept,
-        isDragReject
-    } = useDropzone({ onDrop, accept: { 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel': [] } });
+        isDragReject,
+        fileRejections
+    } = useDropzone({
+        onDrop,
+        maxSize: MAX_UPLOAD_FILE_SIZE_BYTES,
+        accept: {
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
+            'application/vnd.ms-excel': ['.xls']
+        }
+    });
 
     const style = useMemo(() => ({
         ...baseStyle,
@@ -68,6 +83,18 @@ function FileUploader({ onChange }: { onChange: (files: File[]) => Promise<void>
                 <input {...getInputProps()} />
                 <p>{UI_STRINGS.DRAG_STUDENT_FILE}</p>
             </div>
+            {fileRejections.length > 0 &&
+                <Typography color="error" variant="body2" mt={1}>
+                    {fileRejections
+                        .map(({ file, errors }) => {
+                            const reason = errors.some(e => e.code === 'file-too-large')
+                                ? `${UI_STRINGS.FILE_TOO_LARGE_PREFIX} ${MAX_UPLOAD_FILE_SIZE_MB}MB`
+                                : UI_STRINGS.FILE_INVALID_TYPE;
+                            return `${file.name}: ${reason}`;
+                        })
+                        .join(', ')}
+                </Typography>
+            }
         </div>
     );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -140,6 +140,8 @@ export const UI_STRINGS = {
   UNEXPECTED_ERROR_GENERIC: 'Unexpected error:',
   STUDENT_ADDED: 'Student added successfully',
   STUDENT_ADD_FAILED: 'Failed to add student',
+  FILE_TOO_LARGE_PREFIX: 'File is too large. Maximum allowed size is',
+  FILE_INVALID_TYPE: 'File must be an Excel spreadsheet (.xlsx or .xls)',
 } as const;
 
 export const SERVICE_ERRORS = {
@@ -192,3 +194,7 @@ export const OFFICE_HOURS = Array.from({ length: ENDING_HOUR - STARTING_HOUR + 1
 
 // Default number of rows per page in tables
 export const DEFAULT_TABLE_PAGE_SIZE = 25;
+
+// Maximum allowed size for a spreadsheet upload (Students / Cohort upload)
+export const MAX_UPLOAD_FILE_SIZE_MB = 5;
+export const MAX_UPLOAD_FILE_SIZE_BYTES = MAX_UPLOAD_FILE_SIZE_MB * 1024 * 1024;


### PR DESCRIPTION
## Description

Split out from the original CEMT-151 PR per team lead's request. Opened as a **draft** because the max-size behavior needs a requirements decision before this merges (see below) - not blocked on anything technically.

**What this changes**:
- `FileUploader` now caps uploads at 5MB (`MAX_UPLOAD_FILE_SIZE_MB`/`BYTES` in `constants.ts`) and shows an inline rejection message instead of silently starting the upload.
- Also fixes a pre-existing bug in the same dropzone config: the `accept` option was keyed by a single comma-joined MIME-type string (`'mime1, mime2'`), which `react-dropzone` treats as one invalid type rather than two accepted ones. Now `.xlsx`/`.xls` are each declared as their own accepted type, with a clear "must be an Excel spreadsheet" message for anything else.

**Needs a decision before merging**: is a hard 5MB client-side cap the right behavior, or should we instead support larger files via chunked/background upload once the batching fix (#176) is in? 5MB was picked as a reasonable "large enough to freeze the old code path" cutoff for testing, not from an actual requirement. Flagging for discussion rather than assuming.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue # CEMT-151

## QA Instructions, Screenshots, Recordings

- `npx tsc --noEmit` and lint clean.
- Manual: try dragging in a file >5MB and confirm the inline red rejection message appears and no upload starts. Try a non-Excel file (e.g. a `.csv` or `.pdf`) and confirm the "must be an Excel spreadsheet" message appears.