### PR TITLE
CEMT-85: Fix cohort deletion when plans have groups

### DIFF
--- a/src/pages/cohorts/CohortCard.tsx
+++ b/src/pages/cohorts/CohortCard.tsx
@@ -51,10 +51,16 @@ export const CohortCard = (props: { cohort: Cohort }) => {
             cohortDao.delete(props.cohort.id)
                 .then(() => {
                     setRefresh(refresh + 1);
-                    setOpenDeleteDialog(false);
-                    setAnchorEl(null);
                     navigate(`/cohorts`);
                     notifications.success(`Cohort ${props.cohort.name} has been deleted.`);
+                })
+                .catch((err) => {
+                    console.error(`${UI_STRINGS.DELETION_FAILED_PREFIX} ${err.message}`);
+                    notifications.error(`${UI_STRINGS.DELETION_FAILED_PREFIX} ${err.message}`);
+                })
+                .finally(() => {
+                    setOpenDeleteDialog(false);
+                    setAnchorEl(null);
                 })
         }
     };

--- a/supabase/migrations/000030_cohort_delete_cascade.sql
+++ b/supabase/migrations/000030_cohort_delete_cascade.sql
@@ -1,0 +1,23 @@
+-- CEMT-85: Deleting a cohort failed when one of its plans had groups.
+-- plan.cohort_id already cascades from cohort (see 000009_db_cohort_delete.sql)
+-- and placement.plan_id from plan (000011), but grouptable.plan_id and
+-- timewindow.group_id were NO ACTION, so Postgres rejected the delete.
+-- Cascade plan -> grouptable and grouptable -> timewindow.
+-- placement.group_id is deliberately left NO ACTION: planGenerator.emptyPlan
+-- deletes groups while the plan survives, and a cascade there would delete placements.
+
+ALTER TABLE
+    grouptable DROP CONSTRAINT grouptable_plan_id_fkey;
+
+ALTER TABLE
+    grouptable
+ADD
+    CONSTRAINT grouptable_plan_id_fkey FOREIGN KEY (plan_id) REFERENCES plan(id) ON DELETE CASCADE;
+
+ALTER TABLE
+    timewindow DROP CONSTRAINT timewindow_group_id_fkey;
+
+ALTER TABLE
+    timewindow
+ADD
+    CONSTRAINT timewindow_group_id_fkey FOREIGN KEY (group_id) REFERENCES grouptable(id) ON DELETE CASCADE;


### PR DESCRIPTION
Deleting a cohort failed whenever one of its plans had groups. Nothing was removed and no error appeared, so the cohort simply stayed on the screen. A cohort whose plans had no groups deleted without any trouble, which is why the behaviour looked inconsistent.

The cause was a missing delete rule in the database. Removing a cohort is meant to cascade down and remove its plans, and that part worked. The chain broke one level lower, because the link from groups back to their plan had no rule on it. Postgres refuses to remove a plan that still has groups attached, and since it is all one operation, the whole delete was abandoned.

Changes

New migration 000030_cohort_delete_cascade.sql sets grouptable.plan_id and timewindow.group_id to ON DELETE CASCADE.

placement.group_id is deliberately left as NO ACTION. planGenerator.emptyPlan deletes groups while the plan survives, and a cascade there would take the placements with them. Test case 3 below confirms that protection still holds.

CohortCard.tsx now follows the same delete shape as PlanCard.tsx. The .catch reports the failure with notifications.error, and .finally closes the confirmation dialog whether or not the delete succeeded. Previously only the success path existed, so a failed delete left the dialog open with nothing shown to the user. That covers the second half of the report.

Testing

Three cases were run against the applied schema, each inside a transaction that was rolled back so nothing persisted.

Case 1, the reported shape, a cohort with a plan, a group, and a timewindow. Deleted cleanly, all rows removed.

Case 2, two groups, two placements across them, four timewindows, and an enrollment. Deleted cleanly. Students were untouched, which is correct since nothing cascades to student.

Case 3, deleting a group while the plan survives and a placement still points at it. Failed as intended on placement_group_id_fkey, with the plan and placement left intact.

Manual testing through the app used a seeded cohort with one plan, two groups, three placements, and four timewindows. Deleting it succeeded with the children removed and the student rows intact. A cohort with a plan and no groups also still deletes, confirming the path that already worked is unaffected. The error path was checked by temporarily reverting the constraint in a local database, which produced the error toast and closed the dialog.

Deployment

The GitHub workflows deploy the app but do not run migrations. This fix does not take effect on QA or production until someone with Supabase dashboard access applies 000030_cohort_delete_cascade.sql to those projects.


https://github.com/user-attachments/assets/172d8e0f-1882-4e7f-b542-7d92782a5386


https://github.com/user-attachments/assets/65899bda-6a7a-467c-b055-a05b2a2cafd6

